### PR TITLE
feat: add Grok MLB News screamsheet ("MLB News from X")

### DIFF
--- a/screamsheet_new.sh
+++ b/screamsheet_new.sh
@@ -115,6 +115,22 @@ PYEOF
 generate_sheet "MLB Trade Rumors" "$NEWS_PY"
 rm -f "$NEWS_PY"
 
+# --- Grok MLB News Screamsheet ---
+GROK_PY=$(mktemp /tmp/screamsheet_grok_XXXXXX.py)
+cat > "$GROK_PY" <<PYEOF
+from screamsheet import ScreamsheetFactory
+sheet = ScreamsheetFactory.create_grok_mlb_news_screamsheet(
+    output_filename='Files/MLB_Grok_News_${DATE}.pdf',
+    favorite_teams=['Phillies', 'Padres', 'Yankees'],
+    max_articles=4,
+    include_weather=False
+)
+sheet.generate()
+print("Grok MLB News screamsheet generated: Files/MLB_Grok_News_${DATE}.pdf")
+PYEOF
+generate_sheet "Grok MLB News" "$GROK_PY"
+rm -f "$GROK_PY"
+
 echo "[$(date +%T)] Generation phase complete. Starting print jobs..." >> "$LOG_FILE"
 
 # ---------------------------------------------------------------------------
@@ -124,5 +140,6 @@ print_sheet "MLB"              "./Files/MLB_Scores_${DATE}.pdf"
 print_sheet "NHL"              "./Files/NHL_Scores_${DATE}.pdf"
 print_sheet "NBA"              "./Files/NBA_Scores_${DATE}.pdf"
 print_sheet "MLB Trade Rumors" "./Files/MLB_Trade_Rumors_${DATE}.pdf"
+print_sheet "Grok MLB News"    "./Files/MLB_Grok_News_${DATE}.pdf"
 
 echo "--- Execution Finished: $(date) ---" >> "$LOG_FILE"

--- a/src/screamsheet/factory.py
+++ b/src/screamsheet/factory.py
@@ -3,7 +3,7 @@ from typing import Optional
 from datetime import datetime
 
 from .sports import MLBScreamsheet, NHLScreamsheet, NFLScreamsheet, NBAScreamsheet
-from .news import MLBTradeRumorsScreamsheet, PlayersTribuneScreamsheet, FanGraphsScreamsheet
+from .news import MLBTradeRumorsScreamsheet, PlayersTribuneScreamsheet, FanGraphsScreamsheet, GrokMLBNewsScreamsheet
 
 
 class ScreamsheetFactory:
@@ -221,6 +221,38 @@ class ScreamsheetFactory:
         """
         return FanGraphsScreamsheet(
             output_filename=output_filename,
+            max_articles=max_articles,
+            include_weather=include_weather,
+            date=date,
+        )
+
+    @staticmethod
+    def create_grok_mlb_news_screamsheet(
+        output_filename: str,
+        favorite_teams: Optional[list] = None,
+        max_articles: int = 4,
+        include_weather: bool = True,
+        date: Optional[datetime] = None,
+    ) -> GrokMLBNewsScreamsheet:
+        """
+        Create a Grok MLB News screamsheet.
+
+        Grok searches live MLB news from the past 24 hours and writes
+        each article from scratch.  No RSS feed required.
+
+        Args:
+            output_filename: Path to save the PDF.
+            favorite_teams:  Teams to feature first (default: Phillies, Padres, Yankees).
+            max_articles:    Number of articles to generate (default: 4).
+            include_weather: Include weather report (default: True).
+            date:            Target date (defaults to today).
+
+        Returns:
+            GrokMLBNewsScreamsheet instance
+        """
+        return GrokMLBNewsScreamsheet(
+            output_filename=output_filename,
+            favorite_teams=favorite_teams,
             max_articles=max_articles,
             include_weather=include_weather,
             date=date,

--- a/src/screamsheet/news/__init__.py
+++ b/src/screamsheet/news/__init__.py
@@ -3,10 +3,12 @@ from .base_news import NewsScreamsheet
 from .mlb_trade_rumors import MLBTradeRumorsScreamsheet
 from .players_tribune import PlayersTribuneScreamsheet
 from .fangraphs import FanGraphsScreamsheet
+from .grok_mlb_news import GrokMLBNewsScreamsheet
 
 __all__ = [
     'NewsScreamsheet',
     'MLBTradeRumorsScreamsheet',
     'PlayersTribuneScreamsheet',
     'FanGraphsScreamsheet',
+    'GrokMLBNewsScreamsheet',
 ]

--- a/src/screamsheet/news/grok_mlb_news.py
+++ b/src/screamsheet/news/grok_mlb_news.py
@@ -1,0 +1,63 @@
+"""Grok MLB News screamsheet implementation.
+
+Four articles, each sourced and written by Grok searching live MLB news
+from the past 24 hours.  Layout is identical to the MLB Trade Rumors
+screamsheet.
+"""
+from typing import Optional, List
+from datetime import datetime
+
+from .base_news import NewsScreamsheet
+from ..base import Section
+from ..renderers import WeatherSection
+from ..renderers.grok_articles import GrokGeneratedArticlesSection
+from ..providers.grok_mlb_news_provider import GrokMLBNewsProvider
+
+
+class GrokMLBNewsScreamsheet(NewsScreamsheet):
+    """Screamsheet powered by Grok live MLB news search."""
+
+    def __init__(
+        self,
+        output_filename: str,
+        favorite_teams: Optional[List[str]] = None,
+        max_articles: int = 4,
+        include_weather: bool = True,
+        date: Optional[datetime] = None,
+    ):
+        super().__init__(
+            news_source='MLB News from X',
+            output_filename=output_filename,
+            include_weather=include_weather,
+            date=date,
+        )
+        self.favorite_teams = favorite_teams or ['Phillies', 'Padres', 'Yankees']
+        self.max_articles = max_articles
+        # Provider is instantiated once; both renderers share it so articles
+        # are fetched in a single pass and cached on self.provider._articles.
+        self.provider = GrokMLBNewsProvider(
+            favorite_teams=self.favorite_teams,
+            max_articles=self.max_articles,
+        )
+
+    def build_sections(self) -> List[Section]:
+        sections = []
+
+        if self.include_weather:
+            sections.append(WeatherSection(title='Weather Report', date=self.date))
+
+        sections.append(GrokGeneratedArticlesSection(
+            title='MLB News',
+            provider=self.provider,
+            max_articles=2,
+            start_index=0,
+        ))
+
+        sections.append(GrokGeneratedArticlesSection(
+            title='More MLB News',
+            provider=self.provider,
+            max_articles=2,
+            start_index=2,
+        ))
+
+        return sections

--- a/src/screamsheet/providers/grok_mlb_news_provider.py
+++ b/src/screamsheet/providers/grok_mlb_news_provider.py
@@ -1,0 +1,219 @@
+"""Grok-generated MLB news provider.
+
+Instead of scraping an RSS feed, this provider asks Grok to search for
+recent MLB stories directly, compose a full journalist-style article for
+each one, and return them ready for the renderer.  No second summarization
+pass is needed.
+"""
+import os
+from datetime import datetime
+from typing import List, Dict, Optional
+
+from ..base import DataProvider
+
+
+_GROK_MODEL = 'grok-3-fast'
+_GROK_BASE_URL = 'https://api.x.ai/v1'
+
+_SYSTEM_PROMPT = (
+    "You are a sharp, witty sports journalist covering Major League Baseball. "
+    "You have access to live news search. When asked for a story you will search "
+    "recent news (past 24 hours) and write a complete article. "
+    "Do NOT cite X (Twitter) or any social media post as your primary source — "
+    "cite the original outlet, official team statement, or wire service instead."
+)
+
+_STORY_PROMPT_TEMPLATE = """\
+Find and write a significant MLB news story from the past 24 hours.
+{team_instruction}
+{exclusion_instruction}
+
+Format your response EXACTLY like this (two-line header, then body):
+TITLE: <headline, 8 words or fewer>
+
+BODY:
+<full article, ~250-300 words, plain text, no markdown, no bullet points>
+
+Requirements for the article body:
+- Break into logical paragraphs of 1-3 sentences each.
+- Start factual and clean, get livelier toward the end.
+- Use humor where appropriate.
+- Use real words — no slang contractions like "'em", "snaggin'", etc.
+- Do NOT cite X, Twitter, or any social media as your primary source.
+- Do NOT repeat any of the excluded headlines listed above.
+"""
+
+
+class GrokMLBNewsProvider(DataProvider):
+    """
+    Data provider that uses Grok (with live search) to generate MLB news articles.
+
+    Each call to get_articles() makes `max_articles` sequential Grok requests,
+    passing previously generated headlines as exclusions so stories don't repeat.
+
+    Args:
+        favorite_teams: Teams to feature first (first story biased toward
+                        favorite_teams[0]).  Defaults to Phillies, Padres, Yankees.
+        max_articles:   Number of articles to generate (default 4).
+        grok_api_key:   xAI API key.  Falls back to GROK_API_KEY env var.
+    """
+
+    def __init__(
+        self,
+        favorite_teams: Optional[List[str]] = None,
+        max_articles: int = 4,
+        grok_api_key: Optional[str] = None,
+        **config,
+    ):
+        super().__init__(**config)
+        self.favorite_teams = favorite_teams or ['Phillies', 'Padres', 'Yankees']
+        self.max_articles = max_articles
+        self._api_key = grok_api_key or os.getenv('GROK_API_KEY')
+        self._client = self._init_client()
+        self._articles_cache: Optional[List[Dict]] = None  # populated on first call
+
+    # ------------------------------------------------------------------
+    # DataProvider stubs
+    # ------------------------------------------------------------------
+
+    def get_game_scores(self, date: datetime) -> list:
+        return []
+
+    def get_standings(self):
+        return None
+
+    # ------------------------------------------------------------------
+    # Main public method
+    # ------------------------------------------------------------------
+
+    def get_articles(self) -> List[Dict]:
+        """
+        Generate `max_articles` unique MLB news articles via Grok.
+
+        Returns a list of dicts compatible with the standard article shape:
+            {'slot': 'Section N', 'entry': {title, summary, link, id, pub_date}}
+        """
+        if not self._client:
+            print('GrokMLBNewsProvider: No Grok API key — cannot generate articles.')
+            return []
+
+        # Return cached results so shared provider instances don't re-query Grok
+        if self._articles_cache is not None:
+            return self._articles_cache
+
+        today_str = datetime.now().strftime('%B %d, %Y')
+        used_headlines: List[str] = []
+        articles: List[Dict] = []
+
+        for i in range(self.max_articles):
+            # First story: try to feature the top favorite team
+            if i == 0 and self.favorite_teams:
+                team_instruction = (
+                    f"Prefer a story that involves the {self.favorite_teams[0]} "
+                    "if there is a significant one; otherwise pick the biggest MLB story."
+                )
+            else:
+                team_instruction = "Pick the most significant or interesting MLB story available."
+
+            if used_headlines:
+                exclusion_lines = '\n'.join(f'  - {h}' for h in used_headlines)
+                exclusion_instruction = (
+                    f"Do NOT write about any of these already-covered stories:\n{exclusion_lines}"
+                )
+            else:
+                exclusion_instruction = ''
+
+            prompt = _STORY_PROMPT_TEMPLATE.format(
+                team_instruction=team_instruction,
+                exclusion_instruction=exclusion_instruction,
+            ).strip()
+
+            title, body = self._call_grok(prompt)
+            if not title:
+                print(f'GrokMLBNewsProvider: Empty response for article {i + 1}, skipping.')
+                continue
+
+            used_headlines.append(title)
+            articles.append({
+                'slot': f'Section {i + 1}',
+                'entry': {
+                    'id':               f'grok-mlb-{i + 1}-{datetime.now().timestamp()}',
+                    'title':            title,
+                    'summary':          body,
+                    'link':             '',
+                    'pub_date':         today_str,
+                    'published_parsed': None,
+                },
+            })
+
+        self._articles_cache = articles
+        return articles
+
+    def _init_client(self):
+        """Build a ChatOpenAI-compatible Grok client, or return None."""
+        if not self._api_key:
+            return None
+        try:
+            from langchain_openai import ChatOpenAI
+            return ChatOpenAI(
+                model=_GROK_MODEL,
+                temperature=0.5,
+                openai_api_key=self._api_key,
+                base_url=_GROK_BASE_URL,
+                model_kwargs={'extra_headers': {'x-search-mode': 'auto'}},
+            )
+        except Exception as e:
+            print(f'GrokMLBNewsProvider: Failed to initialise Grok client: {e}')
+            return None
+
+    def _call_grok(self, user_prompt: str):
+        """
+        Call Grok with the system + user prompt.  Returns (title, body) tuple.
+        Returns ('', '') on any failure.
+        """
+        from langchain_core.messages import SystemMessage, HumanMessage
+        from langchain_core.output_parsers import StrOutputParser
+
+        try:
+            messages = [
+                SystemMessage(content=_SYSTEM_PROMPT),
+                HumanMessage(content=user_prompt),
+            ]
+            response: str = (self._client | StrOutputParser()).invoke(messages)
+            return self._parse_response(response)
+        except Exception as e:
+            print(f'GrokMLBNewsProvider: Grok call failed: {e}')
+            return '', ''
+
+    @staticmethod
+    def _parse_response(response: str):
+        """
+        Parse the structured TITLE / BODY response from Grok.
+        Returns (title, body) strings.
+        """
+        title = ''
+        body = ''
+        lines = response.strip().splitlines()
+
+        for i, line in enumerate(lines):
+            if line.upper().startswith('TITLE:'):
+                title = line[len('TITLE:'):].strip()
+            elif line.upper().startswith('BODY:'):
+                # Everything after the BODY: line
+                body = '\n'.join(lines[i + 1:]).strip()
+                break
+
+        # Fallback: if no markers found, treat first line as title, rest as body
+        if not title and lines:
+            title = lines[0].strip()
+            body = '\n'.join(lines[1:]).strip()
+
+        return title, body
+
+    # ------------------------------------------------------------------
+    # Required by NewsArticlesSection (sanitize_articles stub)
+    # ------------------------------------------------------------------
+
+    def sanitize_articles(self, articles: List[Dict]) -> List[Dict]:
+        """Articles are already clean — pass through unchanged."""
+        return articles

--- a/src/screamsheet/renderers/__init__.py
+++ b/src/screamsheet/renderers/__init__.py
@@ -5,6 +5,7 @@ from .box_score import BoxScoreSection
 from .game_summary import GameSummarySection
 from .weather import WeatherSection
 from .news_articles import NewsArticlesSection
+from .grok_articles import GrokGeneratedArticlesSection
 
 __all__ = [
     'GameScoresSection',
@@ -13,4 +14,5 @@ __all__ = [
     'GameSummarySection',
     'WeatherSection',
     'NewsArticlesSection',
+    'GrokGeneratedArticlesSection',
 ]

--- a/src/screamsheet/renderers/grok_articles.py
+++ b/src/screamsheet/renderers/grok_articles.py
@@ -1,0 +1,121 @@
+"""Renderer for Grok-generated articles.
+
+Articles arrive pre-written from GrokMLBNewsProvider, so this renderer
+skips the LLM summarization pass entirely and goes straight to layout.
+The two-column Table layout mirrors NewsArticlesSection exactly.
+"""
+from typing import List, Any
+
+from reportlab.platypus import Table, TableStyle, Spacer, Paragraph
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.lib.enums import TA_LEFT
+
+from ..base import Section
+
+
+class GrokGeneratedArticlesSection(Section):
+    """
+    Renders pre-written Grok articles in the standard two-column news layout.
+
+    No LLM summarization is performed — the provider has already composed the
+    final copy.
+
+    Args:
+        title:        Section heading label.
+        provider:     A GrokMLBNewsProvider instance.
+        max_articles: Number of articles to display (default 2).
+        start_index:  Offset into the provider's article list (default 0).
+    """
+
+    def __init__(
+        self,
+        title: str,
+        provider,
+        max_articles: int = 2,
+        start_index: int = 0,
+    ):
+        super().__init__(title)
+        self.provider = provider
+        self.max_articles = max_articles
+        self.start_index = start_index
+
+        base = getSampleStyleSheet()
+        self.article_heading_style = ParagraphStyle(
+            'GrokHeading', parent=base['h4'],
+            fontName='Helvetica-Bold', fontSize=12, spaceAfter=6,
+        )
+        self.article_date_style = ParagraphStyle(
+            'GrokDate', parent=base['Normal'],
+            fontName='Helvetica-Oblique', fontSize=9,
+            textColor='#666666', spaceAfter=6,
+        )
+        self.article_text_style = ParagraphStyle(
+            'GrokText', parent=base['Normal'],
+            fontName='Helvetica', fontSize=10,
+        )
+
+    # ------------------------------------------------------------------
+    # Section protocol
+    # ------------------------------------------------------------------
+
+    def fetch_data(self):
+        """Retrieve articles from the provider (no summarization)."""
+        try:
+            all_articles = self.provider.get_articles()
+            self.data = all_articles[self.start_index: self.start_index + self.max_articles]
+        except Exception as e:
+            print(f'GrokGeneratedArticlesSection: Error fetching articles: {e}')
+            self.data = []
+
+    def render(self) -> List[Any]:
+        """Render articles into the standard two-column Table layout."""
+        if not self.data:
+            self.fetch_data()
+        if not self.data:
+            return []
+
+        left_column: List[Any] = []
+        right_column: List[Any] = []
+
+        for i, article in enumerate(self.data):
+            entry = article.get('entry', {})
+            title = entry.get('title', 'Untitled')
+            body = entry.get('summary', '')
+            pub_date = entry.get('pub_date')
+
+            article_elements: List[Any] = [
+                Paragraph(f'<b>{title}</b>', self.article_heading_style),
+            ]
+
+            if pub_date:
+                article_elements.append(
+                    Paragraph(pub_date, self.article_date_style)
+                )
+
+            # Split body into paragraphs on blank lines
+            paragraphs = [p for p in body.split('\n\n') if p.strip()]
+            for para in paragraphs:
+                article_elements.append(
+                    Paragraph(para.replace('\n', ' '), self.article_text_style)
+                )
+                article_elements.append(Spacer(1, 6))
+
+            article_elements.append(Spacer(1, 12))
+
+            if i % 2 == 0:
+                left_column.extend(article_elements)
+            else:
+                right_column.extend(article_elements)
+
+        news_table = Table(
+            [[left_column, right_column]],
+            colWidths=[270, 270],
+        )
+        news_table.setStyle(TableStyle([
+            ('VALIGN',        (0, 0), (-1, -1), 'TOP'),
+            ('LEFTPADDING',   (0, 0), (0,  0),  0),
+            ('RIGHTPADDING',  (1, 0), (1,  0),  0),
+            ('RIGHTPADDING',  (0, 0), (0,  0),  10),
+        ]))
+
+        return [news_table]


### PR DESCRIPTION
- Add src/screamsheet/providers/grok_mlb_news_provider.py
  - Sequential Grok API calls with live X/Twitter search (x-search-mode: auto)
  - Accumulates used_headlines between calls to prevent duplicate stories
  - Results cached so two renderer sections share one API pass (4 calls total)
  - favorite_teams configurable, defaults to Phillies/Padres/Yankees
  - Explicit prompt instruction to ban X/Twitter as cited source

- Add src/screamsheet/renderers/grok_articles.py
  - GrokGeneratedArticlesSection: two-column layout identical to NewsArticlesSection
  - No re-summarization step — Grok composes final copy directly

- Add src/screamsheet/news/grok_mlb_news.py
  - GrokMLBNewsScreamsheet mirrors MLBTradeRumorsScreamsheet structure
  - Subtitle: "MLB News from X"
  - WeatherSection optional (default: include_weather=False)
  - Two GrokGeneratedArticlesSection blocks (articles 0-1 and 2-3)

- Update src/screamsheet/news/__init__.py — export GrokMLBNewsScreamsheet
- Update src/screamsheet/renderers/__init__.py — export GrokGeneratedArticlesSection
- Update src/screamsheet/factory.py — add create_grok_mlb_news_screamsheet()
- Update screamsheet_new.sh — add Grok MLB News generation + print block
  - Output: Files/MLB_Grok_News_${DATE}.pdf
  - Follows same error-isolated generate_sheet/print_sheet pattern