### PR TITLE
feat(sky): add Sky Tonight screamsheet (#62)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,10 +38,15 @@ nfl:
 
 weather:
   presidential:
-    lat: 34.8697
-    lon: -111.7610
-    location_name: "Sedona, AZ"
+    lat: 40.02
+    lon: -75.34
+    location_name: "Bryn Mawr, PA"
   mlb_news:
     lat: 40.02
     lon: -75.34
     location_name: "Bryn Mawr, PA"
+
+sky:
+  lat: 40.02
+  lon: -75.34
+  location_name: "Bryn Mawr, PA"

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -53,3 +53,10 @@ weather:
     lat: 40.02
     lon: -75.34
     location_name: "Bryn Mawr, PA"
+
+# Sky Tonight location.
+# Find lat/lon for your city at https://www.latlong.net/
+sky:
+  lat: 40.02
+  lon: -75.34
+  location_name: "Bryn Mawr, PA"

--- a/documentation/sky-tonight/ISSUE_62_SKY_TONIGHT_SHEET.md
+++ b/documentation/sky-tonight/ISSUE_62_SKY_TONIGHT_SHEET.md
@@ -1,0 +1,58 @@
+## Feature Overview
+Add a new screamsheet type that generates a printable, one-page PDF every morning summarizing the naked-eye night sky: planetary positions in zodiac, visible constellations, and a short AI-generated summary. The LLM prompt should adopt the persona of an enthusiastic amateur astronomer AND someone playfully interested in astrology (but not seriously), always focusing on naked eye observations (never telescopes).
+
+---
+
+### Step-by-Step Plan
+
+**1. Dependencies & Setup**
+- [ ] Add `skyfield` to requirements (planet positions, zodiac mapping; optionally use for ISS passes, moon phase)
+- [ ] Add any assets needed for constellation boundaries (e.g. CSV files)
+
+**2. Data Provider**
+- [ ] Create `src/screamsheet/providers/sky_provider.py`
+  - [ ] Compute ecliptic longitudes for all classical planets (Mercury → Pluto), moon, and sun for tonight
+  - [ ] Map planet positions to zodiac constellations
+  - [ ] Determine which constellations are above the horizon at local sunset/astronomical dusk
+  - [ ] Identify highlights: conjunctions, close approaches, ISS passes, meteor showers (as list of dicts, each ≤1 line)
+  - [ ] Filter for naked-eye only (planets brighter than ~mag 6.5); Uranus/Neptune/Pluto only for chart, not in AI summary
+
+**3. Renderers**
+- [ ] Create `renderers/zodiac_wheel.py`: draws a stylized circle with 12 zodiac wedges, planets marked, and a shaded band for visible portion
+- [ ] Create `renderers/sky_highlights.py`: renders a bulleted highlights section (including LLM-generated text)
+
+**4. LLM / AI Summary**
+- [ ] Update or add to `src/screamsheet/llm/` as needed to support a prompt:
+    - Persona: "Enthusiastic amateur astronomer who loves naked eye observations and is also playfully interested in astrology. Never recommends telescopes."
+    - Output: 3–6 concise bullets or 2-sentence narrative + bullets, based on provided highlight data
+
+**5. Screamsheet Glue**
+- [ ] Add new screamsheet type at `src/screamsheet/sky/sky_tonight.py`
+- [ ] Wire up to factory in `factory.py` as `create_sky_tonight_screamsheet()`
+- [ ] Add entry to `config.yaml.example` (lat, lon, location_name)
+- [ ] Update main script/cron for daily execution and printout
+
+**6. Testing**
+- [ ] Create tests in `tests/test_sky_provider.py` and check date/location edge cases (e.g. polar day/night)
+
+---
+
+**Extra**
+- [ ] Make sure summary sections never suggest needing a telescope
+- [ ] Output supports both astronomy and fun/astrology remarks where appropriate (in a tongue-in-cheek way)
+- [ ] Code modular to allow additional "tonight" style sheets in future
+
+---
+
+### Example Output (expected)
+
+- Zodiac wheel showing planet positions (dots with labels)
+- Shaded arc for visible constellations
+- Bullet points like:
+  - "Venus is brilliant in the west after dusk, just above Taurus."
+  - "Jupiter and Mars form a striking pair in Gemini."
+  - "The waxing crescent Moon is in Leo tonight."
+  - "No major meteor showers, but the ISS passes overhead at 9:17pm."
+  - *(And a fun line)*: "Mercury winks at Virgo — perhaps it's a night for clever ideas!"
+
+---

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,3 +11,9 @@ ignore_missing_imports = True
 # Configuration to ignore missing stubs for the pytest library
 [mypy-pytest]
 ignore_missing_imports = True
+
+[mypy-yaml]
+ignore_missing_imports = True
+
+[mypy-skyfield.*]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ dependencies = [
     "xxhash==3.6.0",
     "yarl==1.22.0",
     "zstandard==0.25.0",
+    "skyfield>=1.48",
 ]
 
 [project.scripts]

--- a/screamsheet.sh
+++ b/screamsheet.sh
@@ -44,6 +44,7 @@ print_sheet() {
 #      ../Files/MLB_trade_rumors_YYYYMMDD.pdf
 #      ../Files/MLB_NEWS_YYYYMMDD.pdf
 #      ../Files/presidential_screamsheet_YYYYMMDD.pdf
+#      ../Files/SKY_YYYYMMDD.pdf
 # ---------------------------------------------------------------------------
 echo "[$(date +%T)] Generating screamsheets..." >> "$LOG_FILE"
 uv run python -m screamsheet >> "$LOG_FILE" 2>&1
@@ -65,5 +66,6 @@ print_sheet "NHL Game Scores"          "./Files/NHL_gamescores_${DATE}.pdf"
 print_sheet "MLB Trade Rumors"         "./Files/MLB_trade_rumors_${DATE}.pdf"
 print_sheet "MLB News"                 "./Files/MLB_NEWS_${DATE}.pdf"
 print_sheet "Presidential Screamsheet" "./Files/presidential_screamsheet_${DATE}.pdf"
+print_sheet "Sky Tonight"              "./Files/SKY_${DATE}.pdf"
 
 echo "--- Execution Finished: $(date) ---" >> "$LOG_FILE"

--- a/src/screamsheet/__main__.py
+++ b/src/screamsheet/__main__.py
@@ -12,6 +12,7 @@ from .config import load_config
 from .sports import MLBScreamsheet, NHLScreamsheet, NFLScreamsheet, NBAScreamsheet
 from .news import MLBTradeRumorsScreamsheet, MLBNewsScreamsheet
 from .political import PresidentialScreamsheet
+from .sky.sky_tonight import SkyTonightScreamsheet
 
 __all__ = [
     'ScreamsheetFactory',
@@ -22,6 +23,7 @@ __all__ = [
     'MLBTradeRumorsScreamsheet',
     'MLBNewsScreamsheet',
     'PresidentialScreamsheet',
+    'SkyTonightScreamsheet',
 ]
 
 
@@ -35,8 +37,7 @@ def _build_sheets(today_str: str) -> list:
     nhl_teams = [(t.id, t.name) for t in cfg.nhl.favorite_teams]
     mlb_news_names = cfg.mlb.news_names
 
-    return [
-        (
+    return [        (
             "MLB  — " + (cfg.mlb.favorite_teams[0].name if cfg.mlb.favorite_teams else ""),
             lambda: ScreamsheetFactory.create_mlb_screamsheet(
                 output_filename=f'Files/MLB_gamescores_{today_str}.pdf',
@@ -87,6 +88,16 @@ def _build_sheets(today_str: str) -> list:
                 weather_lat=cfg.weather.presidential.lat,
                 weather_lon=cfg.weather.presidential.lon,
                 weather_location_name=cfg.weather.presidential.location_name,
+                date=today,
+            ),
+        ),
+        (
+            "Sky Tonight — " + cfg.sky.location_name,
+            lambda: ScreamsheetFactory.create_sky_tonight_screamsheet(
+                output_filename=f'Files/SKY_{today_str}.pdf',
+                lat=cfg.sky.lat,
+                lon=cfg.sky.lon,
+                location_name=cfg.sky.location_name,
                 date=today,
             ),
         ),

--- a/src/screamsheet/config.py
+++ b/src/screamsheet/config.py
@@ -55,6 +55,14 @@ class WeatherConfig:
 
 
 @dataclass
+class SkyConfig:
+    """Location config for the sky tonight screamsheet."""
+    lat: float = 40.0
+    lon: float = -75.0
+    location_name: str = "My Location"
+
+
+@dataclass
 class ScreamsheetConfig:
     """Top-level config object, one SportConfig per sport."""
     nhl: SportConfig = field(default_factory=SportConfig)
@@ -62,6 +70,7 @@ class ScreamsheetConfig:
     nba: SportConfig = field(default_factory=SportConfig)
     nfl: SportConfig = field(default_factory=SportConfig)
     weather: WeatherConfig = field(default_factory=WeatherConfig)
+    sky: SkyConfig = field(default_factory=SkyConfig)
 
 
 def _parse_sport(raw: dict) -> SportConfig:
@@ -99,6 +108,14 @@ def _parse_weather(raw: dict) -> WeatherConfig:
     )
 
 
+def _parse_sky(raw: dict) -> SkyConfig:
+    return SkyConfig(
+        lat=float(raw.get("lat", 40.0)),
+        lon=float(raw.get("lon", -75.0)),
+        location_name=str(raw.get("location_name", "My Location")),
+    )
+
+
 def load_config(path: Path = _CONFIG_PATH) -> ScreamsheetConfig:
     """Load and parse config.yaml.
 
@@ -130,4 +147,5 @@ def load_config(path: Path = _CONFIG_PATH) -> ScreamsheetConfig:
         nba=_parse_sport(raw.get("nba", {})),
         nfl=_parse_sport(raw.get("nfl", {})),
         weather=_parse_weather(raw.get("weather", {})),
+        sky=_parse_sky(raw.get("sky", {})),
     )

--- a/src/screamsheet/factory.py
+++ b/src/screamsheet/factory.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from .sports import MLBScreamsheet, NHLScreamsheet, NFLScreamsheet, NBAScreamsheet
 from .news import MLBTradeRumorsScreamsheet, MLBNewsScreamsheet, PlayersTribuneScreamsheet, FanGraphsScreamsheet, GrokMLBNewsScreamsheet
 from .political import PresidentialScreamsheet
+from .sky.sky_tonight import SkyTonightScreamsheet
 
 
 class ScreamsheetFactory:
@@ -356,5 +357,38 @@ class ScreamsheetFactory:
             weather_lat=weather_lat,
             weather_lon=weather_lon,
             weather_location_name=weather_location_name,
+            date=date,
+        )
+
+    @staticmethod
+    def create_sky_tonight_screamsheet(
+        output_filename: str,
+        lat: float = 40.0,
+        lon: float = -75.0,
+        location_name: str = "My Location",
+        date: Optional[datetime] = None,
+    ) -> SkyTonightScreamsheet:
+        """
+        Create a Sky Tonight screamsheet.
+
+        Generates a one-page PDF summarising the naked-eye night sky for
+        the configured location: a zodiac wheel showing planet positions
+        and a bulleted highlights section with an optional LLM remark.
+
+        Args:
+            output_filename: Path to save the PDF.
+            lat:             Observer latitude (decimal degrees).
+            lon:             Observer longitude (decimal degrees).
+            location_name:   Display name for the observer location.
+            date:            Target date (defaults to today).
+
+        Returns:
+            SkyTonightScreamsheet instance
+        """
+        return SkyTonightScreamsheet(
+            output_filename=output_filename,
+            lat=lat,
+            lon=lon,
+            location_name=location_name,
             date=date,
         )

--- a/src/screamsheet/llm/__init__.py
+++ b/src/screamsheet/llm/__init__.py
@@ -6,7 +6,7 @@ Public API — prefer importing from here rather than from sub-modules::
 """
 from .config import LLMConfig, DEFAULT_LLM_CONFIG
 from .base import BaseGameSummaryGenerator, ExtractedInfo, PromptChainInput
-from .summarizers import NHLGameSummarizer, MLBGameSummarizer, NewsSummarizer, PoliticalNewsSummarizer
+from .summarizers import NHLGameSummarizer, MLBGameSummarizer, NewsSummarizer, PoliticalNewsSummarizer, SkyNightSummarizer
 
 __all__ = [
     "LLMConfig",
@@ -18,4 +18,5 @@ __all__ = [
     "MLBGameSummarizer",
     "NewsSummarizer",
     "PoliticalNewsSummarizer",
+    "SkyNightSummarizer",
 ]

--- a/src/screamsheet/llm/prompts/sky_tonight.txt
+++ b/src/screamsheet/llm/prompts/sky_tonight.txt
@@ -1,0 +1,19 @@
+You are an enthusiastic naked-eye amateur astronomer who also has a playful soft spot for astrology — not in a serious "your destiny is written in the stars" way, but in a fun, winking, tongue-in-cheek way. You get genuinely excited about what you can see in the night sky with your own two eyes. You NEVER recommend telescopes or binoculars — the naked eye is always enough.
+
+Tonight's sky data for {location} on {date}:
+
+Planet positions (zodiac):
+{planets}
+
+Moon: {moon_phase}
+
+Highlights:
+{highlights}
+
+Write 3–6 concise bullet points (one per line, each starting with "•") summarising tonight's sky for a curious amateur observer. Each bullet should:
+- Focus strictly on what can be seen with the naked eye
+- Include at least one playful astrological aside (e.g. "Mercury in Virgo — great night for detail-oriented thinking!")
+- Be vivid and exciting, not dry and textbook
+- Be no longer than one sentence
+
+Output ONLY the bullet points. No preamble, no sign-off.  Start with the astrological aside.

--- a/src/screamsheet/llm/summarizers.py
+++ b/src/screamsheet/llm/summarizers.py
@@ -165,3 +165,35 @@ class PoliticalNewsSummarizer(FilePromptMixin, BaseGameSummaryGenerator):
             grok_api_key=grok_api_key,
             config=config,
         )
+
+
+class SkyNightSummarizer(FilePromptMixin, BaseGameSummaryGenerator):
+    """
+    Generates a sky-tonight narrative bullet list.
+
+    Persona: an enthusiastic naked-eye amateur astronomer who also finds
+    astrology playfully fun.  Never recommends telescopes.
+
+    Expected ``data`` keys
+    ----------------------
+    - ``planets``    str  — formatted planet/zodiac summary line
+    - ``moon_phase`` str  — e.g. "Waxing Crescent (35% illuminated)"
+    - ``highlights`` str  — newline-separated highlight sentences
+    - ``location``   str  — observer location name
+    - ``date``       str  — display date string
+    """
+
+    _PROMPT_FILE = Path("sky_tonight.txt")
+
+    def __init__(
+        self,
+        gemini_api_key: Optional[str] = None,
+        grok_api_key: Optional[str] = None,
+        config: LLMConfig = DEFAULT_LLM_CONFIG,
+    ) -> None:
+        BaseGameSummaryGenerator.__init__(
+            self,
+            gemini_api_key=gemini_api_key,
+            grok_api_key=grok_api_key,
+            config=config,
+        )

--- a/src/screamsheet/llm/summary.py
+++ b/src/screamsheet/llm/summary.py
@@ -15,7 +15,7 @@ continue to work unchanged.
 # isort: skip_file
 from .config import LLMConfig, DEFAULT_LLM_CONFIG  # noqa: F401
 from .base import BaseGameSummaryGenerator, ExtractedInfo, PromptChainInput  # noqa: F401
-from .summarizers import NHLGameSummarizer, MLBGameSummarizer, NewsSummarizer  # noqa: F401
+from .summarizers import NHLGameSummarizer, MLBGameSummarizer, NewsSummarizer, SkyNightSummarizer  # noqa: F401
 
 __all__ = [
     "LLMConfig",

--- a/src/screamsheet/providers/sky_provider.py
+++ b/src/screamsheet/providers/sky_provider.py
@@ -1,0 +1,314 @@
+"""Sky data provider using skyfield for astronomical calculations.
+
+Computes planet ecliptic positions, zodiac sign mappings, moon phase,
+visible constellations, and sky highlights for a given date and location.
+All output is filtered for naked-eye observation (no telescope references).
+"""
+from __future__ import annotations
+
+import math
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..base.data_provider import DataProvider
+
+
+# ---------------------------------------------------------------------------
+# Constellation RA/Dec centers (approximate, J2000)
+# (ra_hours, dec_degrees)
+# ---------------------------------------------------------------------------
+_CONSTELLATION_CENTERS: Dict[str, Tuple[float, float]] = {
+    # Zodiac
+    "Aries": (2.53, 20.8),
+    "Taurus": (4.70, 15.9),
+    "Gemini": (7.07, 26.0),
+    "Cancer": (8.65, 19.8),
+    "Leo": (10.67, 13.1),
+    "Virgo": (13.42, -4.2),
+    "Libra": (15.20, -15.1),
+    "Scorpius": (16.88, -30.3),
+    "Sagittarius": (19.18, -27.3),
+    "Capricorn": (21.05, -17.8),
+    "Aquarius": (22.28, -10.2),
+    "Pisces": (1.15, 15.3),
+    # Prominent non-zodiac
+    "Orion": (5.58, 3.3),
+    "Ursa Major": (11.30, 50.7),
+    "Perseus": (3.50, 45.0),
+    "Cassiopeia": (1.00, 62.0),
+    "Cygnus": (20.60, 44.5),
+    "Lyra": (18.85, 36.5),
+    "Aquila": (19.67, 3.4),
+    "Hercules": (17.38, 27.5),
+    "Boötes": (14.70, 31.2),
+    "Corona Borealis": (15.85, 33.0),
+    "Pegasus": (22.68, 19.5),
+    "Andromeda": (0.80, 38.0),
+}
+
+# ---------------------------------------------------------------------------
+# Meteor showers (approximate peak dates as (month, day))
+# ---------------------------------------------------------------------------
+_METEOR_SHOWERS: List[Dict[str, Any]] = [
+    {"name": "Quadrantids", "peak_month": 1, "peak_day": 3, "window_days": 2, "rate": "120/hr"},
+    {"name": "Lyrids", "peak_month": 4, "peak_day": 22, "window_days": 3, "rate": "20/hr"},
+    {"name": "Eta Aquariids", "peak_month": 5, "peak_day": 6, "window_days": 5, "rate": "50/hr"},
+    {"name": "Perseids", "peak_month": 8, "peak_day": 12, "window_days": 4, "rate": "100/hr"},
+    {"name": "Draconids", "peak_month": 10, "peak_day": 8, "window_days": 2, "rate": "10/hr"},
+    {"name": "Orionids", "peak_month": 10, "peak_day": 21, "window_days": 3, "rate": "20/hr"},
+    {"name": "Leonids", "peak_month": 11, "peak_day": 17, "window_days": 3, "rate": "15/hr"},
+    {"name": "Geminids", "peak_month": 12, "peak_day": 14, "window_days": 3, "rate": "120/hr"},
+    {"name": "Ursids", "peak_month": 12, "peak_day": 22, "window_days": 2, "rate": "10/hr"},
+]
+
+_PLANET_TWO_LETTER: Dict[str, str] = {
+    "Sun": "Su",
+    "Moon": "Mo",
+    "Mercury": "Me",
+    "Venus": "Ve",
+    "Mars": "Ma",
+    "Jupiter": "Ju",
+    "Saturn": "Sa",
+    "Uranus": "Ur",
+    "Neptune": "Ne",
+}
+
+_ZODIAC_SIGNS = [
+    "Aries", "Taurus", "Gemini", "Cancer", "Leo", "Virgo",
+    "Libra", "Scorpius", "Sagittarius", "Capricorn", "Aquarius", "Pisces",
+]
+
+# Naked-eye planets for highlight text (Uranus/Neptune excluded from narration)
+_NAKED_EYE_PLANETS = {"Mercury", "Venus", "Mars", "Jupiter", "Saturn"}
+
+
+class SkyDataProvider(DataProvider):
+    """Provides sky data for a given date and observer location.
+
+    Uses the skyfield library (DE421 ephemeris) to compute planet ecliptic
+    positions, moon phase, and constellation visibility.  All narration is
+    filtered to naked-eye observations only.
+    """
+
+    def __init__(self, lat: float, lon: float, location_name: str) -> None:
+        super().__init__()
+        self.lat = lat
+        self.lon = lon
+        self.location_name = location_name
+
+    # ------------------------------------------------------------------
+    # DataProvider interface stubs (not applicable for sky data)
+    # ------------------------------------------------------------------
+
+    def get_game_scores(self, date: datetime) -> list:
+        return []
+
+    def get_standings(self) -> list:
+        return []
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_sky_data(self, date: datetime) -> Dict[str, Any]:
+        """Return a dict of sky data for *date* at the configured location.
+
+        Keys:
+            planets              List[Dict] — one entry per planet
+            moon_phase           str        — e.g. "Waxing Crescent (35% illuminated)"
+            highlights           List[str]  — bullet-ready highlight sentences
+            visible_constellations List[str] — names visible above horizon at dusk
+        """
+        dusk_time = self._find_astronomical_dusk(date)
+        return {
+            "planets": self._compute_planet_positions(date),
+            "moon_phase": self._compute_moon_phase(date),
+            "highlights": self._get_highlights(date),
+            "visible_constellations": self._get_visible_constellations(date, dusk_time),
+        }
+
+    # ------------------------------------------------------------------
+    # Pure helpers (testable without skyfield)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _ecliptic_lon_to_zodiac(lon_deg: float) -> str:
+        """Map an ecliptic longitude (0–360°) to a zodiac sign name."""
+        idx = int(lon_deg / 30) % 12
+        return _ZODIAC_SIGNS[idx]
+
+    @staticmethod
+    def _moon_phase_name(elongation_deg: float) -> str:
+        """Return the phase name for a Sun–Moon elongation angle (0–360°)."""
+        e = elongation_deg % 360
+        if e < 22.5 or e >= 337.5:
+            return "New Moon"
+        elif e < 67.5:
+            return "Waxing Crescent"
+        elif e < 112.5:
+            return "First Quarter"
+        elif e < 157.5:
+            return "Waxing Gibbous"
+        elif e < 202.5:
+            return "Full Moon"
+        elif e < 247.5:
+            return "Waning Gibbous"
+        elif e < 292.5:
+            return "Last Quarter"
+        else:
+            return "Waning Crescent"
+
+    # ------------------------------------------------------------------
+    # Planet / lunar computation (uses skyfield)
+    # ------------------------------------------------------------------
+
+    def _load_ephemeris(self) -> Tuple[Any, Any]:
+        """Load and return (timescale, ephemeris).  Downloads DE421 on first run."""
+        from skyfield.api import load  # type: ignore[import-untyped]
+        ts = load.timescale()
+        eph = load("de421.bsp")
+        return ts, eph
+
+    def _compute_planet_positions(self, date: datetime) -> List[Dict[str, Any]]:
+        """Compute geocentric ecliptic longitude for each planet."""
+        ts, eph = self._load_ephemeris()
+        # Observe at 22:00 UTC as a reasonable "tonight" proxy
+        t = ts.utc(date.year, date.month, date.day, 22, 0, 0)
+        earth = eph["earth"]
+
+        bodies = [
+            ("Sun", "sun"),
+            ("Moon", "moon"),
+            ("Mercury", "mercury"),
+            ("Venus", "venus"),
+            ("Mars", "mars"),
+            ("Jupiter", "jupiter barycenter"),
+            ("Saturn", "saturn barycenter"),
+            ("Uranus", "uranus barycenter"),
+            ("Neptune", "neptune barycenter"),
+        ]
+
+        planets: List[Dict[str, Any]] = []
+        for name, body_key in bodies:
+            body = eph[body_key]
+            astrometric = earth.at(t).observe(body)
+            _, lon, _ = astrometric.ecliptic_latlon()
+            lon_deg = float(lon.degrees)
+            planets.append(
+                {
+                    "name": name,
+                    "zodiac": self._ecliptic_lon_to_zodiac(lon_deg),
+                    "ecliptic_lon": lon_deg,
+                    "two_letter": _PLANET_TWO_LETTER[name],
+                }
+            )
+        return planets
+
+    def _compute_moon_phase(self, date: datetime) -> str:
+        """Return a human-readable moon phase string with illumination %."""
+        ts, eph = self._load_ephemeris()
+        t = ts.utc(date.year, date.month, date.day, 22, 0, 0)
+        earth = eph["earth"]
+
+        _, sun_lon, _ = earth.at(t).observe(eph["sun"]).ecliptic_latlon()
+        _, moon_lon, _ = earth.at(t).observe(eph["moon"]).ecliptic_latlon()
+
+        elongation = (float(moon_lon.degrees) - float(sun_lon.degrees)) % 360
+        phase_name = self._moon_phase_name(elongation)
+        illumination = round((1 - math.cos(math.radians(elongation))) / 2 * 100)
+        return f"{phase_name} ({illumination}% illuminated)"
+
+    # ------------------------------------------------------------------
+    # Visibility computation
+    # ------------------------------------------------------------------
+
+    def _find_astronomical_dusk(self, date: datetime) -> Optional[Any]:
+        """Return the skyfield Time of astronomical dusk, or None (polar day/night)."""
+        try:
+            from skyfield.api import load, wgs84  # type: ignore[import-untyped]
+            from skyfield import almanac  # type: ignore[import-untyped]
+
+            ts, eph = self._load_ephemeris()
+            observer = wgs84.latlon(self.lat, self.lon)
+            t0 = ts.utc(date.year, date.month, date.day, 18, 0)
+            t1 = ts.utc(date.year, date.month, date.day + 1, 6, 0)
+
+            f = almanac.dark_twilight_day(eph, observer)
+            times, events = almanac.find_discrete(t0, t1, f)
+
+            for event_time, event_val in zip(times, events):
+                if int(event_val) == 0:  # type: ignore[arg-type]
+                    return event_time
+            return None
+        except Exception:  # noqa: BLE001 — skyfield may raise on extreme latitudes
+            return None
+
+    def _get_visible_constellations(
+        self, date: datetime, dusk_time: Optional[Any]
+    ) -> List[str]:
+        """Return names of constellations more than 5° above the horizon at dusk.
+
+        Returns an empty list when *dusk_time* is None (polar day/night).
+        """
+        if dusk_time is None:
+            return []
+
+        try:
+            from skyfield.api import load, wgs84, Star  # type: ignore[import-untyped]
+
+            _, eph = self._load_ephemeris()
+            observer = wgs84.latlon(self.lat, self.lon)
+            location = eph["earth"] + observer
+
+            visible: List[str] = []
+            for name, (ra_h, dec_d) in _CONSTELLATION_CENTERS.items():
+                star = Star(ra_hours=ra_h, dec_degrees=dec_d)
+                apparent = location.at(dusk_time).observe(star).apparent()
+                alt, _, _ = apparent.altaz()
+                if float(alt.degrees) > 5.0:
+                    visible.append(name)
+            return visible
+        except Exception:  # noqa: BLE001
+            return []
+
+    # ------------------------------------------------------------------
+    # Highlights
+    # ------------------------------------------------------------------
+
+    def _get_highlights(self, date: datetime) -> List[str]:
+        """Build a list of highlight sentences for the sky tonight."""
+        highlights: List[str] = []
+        planets = self._compute_planet_positions(date)
+        moon_phase = self._compute_moon_phase(date)
+
+        highlights.append(f"The Moon is {moon_phase}.")
+
+        # Naked-eye planet positions
+        for p in planets:
+            if p["name"] in _NAKED_EYE_PLANETS:
+                highlights.append(f"{p['name']} is in {p['zodiac']}.")
+
+        # Conjunctions: check every pair within 5°
+        for i, a in enumerate(planets):
+            for b in planets[i + 1 :]:
+                if a["name"] not in _NAKED_EYE_PLANETS and b["name"] not in _NAKED_EYE_PLANETS:
+                    continue
+                sep = abs(a["ecliptic_lon"] - b["ecliptic_lon"]) % 360
+                sep = min(sep, 360 - sep)
+                if sep < 5.0:
+                    highlights.append(
+                        f"{a['name']} and {b['name']} are in a close conjunction in {a['zodiac']}."
+                    )
+
+        # Active meteor showers
+        for shower in _METEOR_SHOWERS:
+            days_from_peak = abs(
+                (date.month - shower["peak_month"]) * 30
+                + (date.day - shower["peak_day"])
+            )
+            if days_from_peak <= shower["window_days"]:
+                highlights.append(
+                    f"The {shower['name']} meteor shower is active — up to {shower['rate']}!"
+                )
+
+        return highlights

--- a/src/screamsheet/renderers/__init__.py
+++ b/src/screamsheet/renderers/__init__.py
@@ -6,6 +6,8 @@ from .game_summary import GameSummarySection
 from .weather import WeatherSection
 from .news_articles import NewsArticlesSection
 from .grok_articles import GrokGeneratedArticlesSection
+from .zodiac_wheel import ZodiacWheelSection
+from .sky_highlights import SkyHighlightsSection
 
 __all__ = [
     'GameScoresSection',
@@ -15,4 +17,6 @@ __all__ = [
     'WeatherSection',
     'NewsArticlesSection',
     'GrokGeneratedArticlesSection',
+    'ZodiacWheelSection',
+    'SkyHighlightsSection',
 ]

--- a/src/screamsheet/renderers/sky_highlights.py
+++ b/src/screamsheet/renderers/sky_highlights.py
@@ -1,0 +1,122 @@
+"""Sky highlights section renderer for the Sky Tonight screamsheet.
+
+Renders data-driven bullets from the SkyDataProvider plus an optional
+LLM-generated playful astronomy/astrology bullet at the end.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Any, List, cast
+
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.lib.enums import TA_LEFT
+from reportlab.platypus import Paragraph, Spacer
+
+from ..base import Section
+from ..llm.summarizers import SkyNightSummarizer
+from ..llm.config import DEFAULT_LLM_CONFIG
+
+
+class SkyHighlightsSection(Section):
+    """Renders a bulleted sky-highlights list with an optional LLM finale.
+
+    Args:
+        title:         Section heading.
+        provider:      SkyDataProvider instance.
+        date:          Target date (tonight).
+        location_name: Observer location for the LLM prompt.
+    """
+
+    def __init__(
+        self,
+        title: str,
+        provider: Any,
+        date: datetime,
+        location_name: str,
+    ) -> None:
+        super().__init__(title)
+        self.provider = provider
+        self.date = date
+        self.location_name = location_name
+
+        base = getSampleStyleSheet()
+        self._bullet_style = ParagraphStyle(
+            "SkyBullet",
+            parent=base["Normal"],
+            fontSize=9,
+            leading=12,
+            leftIndent=12,
+            spaceAfter=3,
+        )
+        self._heading_style = base["Heading2"]
+
+    # ------------------------------------------------------------------
+    # Section interface
+    # ------------------------------------------------------------------
+
+    def fetch_data(self) -> None:
+        sky = self.provider.get_sky_data(self.date)
+        self.data = sky.get("highlights", [])
+        self._sky_data = sky  # keep full payload for LLM prompt
+
+    def render(self) -> List[Any]:
+        if self.data is None:
+            self.fetch_data()
+
+        elements: List[Any] = []
+        elements.append(Paragraph(self.title, self._heading_style))
+        elements.append(Spacer(1, 4))
+
+        bullets: List[str] = cast(List[str], self.data) if isinstance(self.data, list) else []
+        for bullet in bullets:
+            elements.append(Paragraph(f"• {bullet}", self._bullet_style))
+
+        # Optional LLM-generated astronomy/astrology bullet
+        llm_bullet = self._get_llm_bullet()
+        if llm_bullet:
+            elements.append(Paragraph(f"• {llm_bullet}", self._bullet_style))
+
+        return elements
+
+    # ------------------------------------------------------------------
+    # LLM integration (graceful no-op if no API keys)
+    # ------------------------------------------------------------------
+
+    def _get_llm_bullet(self) -> str:
+        """Return a single LLM-generated sky bullet, or empty string on failure."""
+        sky = getattr(self, "_sky_data", {})
+        if not sky:
+            return ""
+
+        gemini_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
+        grok_key = os.getenv("GROK_API_KEY") or os.getenv("XAI_API_KEY")
+
+        if not gemini_key and not grok_key:
+            return ""
+
+        try:
+            summarizer = SkyNightSummarizer(
+                gemini_api_key=gemini_key,
+                grok_api_key=grok_key,
+                config=DEFAULT_LLM_CONFIG,
+            )
+            planets_str = ", ".join(
+                f"{p['name']} in {p['zodiac']}"
+                for p in sky.get("planets", [])
+                if p.get("name") not in {"Uranus", "Neptune"}
+            )
+            llm_choice = "gemini" if gemini_key else "grok"
+            result = summarizer.generate_summary(
+                llm_choice=llm_choice,
+                data={
+                    "planets": planets_str,
+                    "moon_phase": sky.get("moon_phase", ""),
+                    "highlights": "\n".join(sky.get("highlights", [])),
+                    "location": self.location_name,
+                    "date": self.date.strftime("%B %d, %Y"),
+                },
+            )
+            return str(result).strip() if result else ""
+        except Exception:  # noqa: BLE001
+            return ""

--- a/src/screamsheet/renderers/zodiac_wheel.py
+++ b/src/screamsheet/renderers/zodiac_wheel.py
@@ -1,0 +1,194 @@
+"""Zodiac wheel renderer for the Sky Tonight screamsheet.
+
+Draws a full circular zodiac wheel using ReportLab vector graphics:
+  - 12 alternating grayscale annular wedges labelled with 3-letter sign abbreviations
+  - Planet astrological symbols at their ecliptic longitude positions
+  - A semi-transparent gray overlay for zodiac signs visible above the horizon
+"""
+from __future__ import annotations
+
+import math
+import os
+from datetime import datetime
+from typing import Any, Dict, List, cast
+
+from reportlab.graphics.shapes import (
+    Drawing,
+    Wedge,
+    Circle,
+    String,
+)
+from reportlab.lib.colors import (
+    HexColor,
+    black,
+    Color,
+)
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.ttfonts import TTFont
+from reportlab.platypus import Paragraph, Spacer
+
+from ..base import Section
+
+# ---------------------------------------------------------------------------
+# Visual constants
+# ---------------------------------------------------------------------------
+_WHEEL_SIZE = 260          # drawing canvas size (points)
+_OUTER_R = 118.0           # outer radius of the sign ring
+_RIM_R = _OUTER_R * 0.90  # label radius (centre of rim band)
+_INNER_R = _OUTER_R * 0.72 # inner edge of sign ring / outer edge of planet zone
+_PLANET_R = _OUTER_R * 0.54  # radius at which planet symbols are placed
+
+# Grayscale alternating wedge fills
+_SIGN_COLORS = (HexColor("#F0F0F0"), HexColor("#D8D8D8"))
+
+# Visible-sign overlay: semi-transparent gray
+_VISIBLE_OVERLAY_GRAY = Color(0.5, 0.5, 0.5, alpha=0.3)
+
+# Astrological symbols for the nine visible planets/luminaries
+_PLANET_SYMBOLS: dict[str, str] = {
+    "Sun":     "\u2609",  # ☉
+    "Moon":    "\u263d",  # ☽
+    "Mercury": "\u263f",  # ☿
+    "Venus":   "\u2640",  # ♀
+    "Mars":    "\u2642",  # ♂
+    "Jupiter": "\u2643",  # ♃
+    "Saturn":  "\u2644",  # ♄
+    "Uranus":  "\u2645",  # ♅
+    "Neptune": "\u2646",  # ♆
+}
+
+# Register a Unicode-capable TTF font for rendering the symbols.
+# Falls back to Helvetica (symbols won't render) if none is found.
+_UNICODE_FONT = "Helvetica"
+_FONT_CANDIDATES = [
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    "/usr/share/fonts/dejavu/DejaVuSans.ttf",
+    "/usr/share/fonts/truetype/freefont/FreeSans.ttf",
+    "/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf",
+]
+for _fp in _FONT_CANDIDATES:
+    if os.path.exists(_fp):
+        try:
+            pdfmetrics.registerFont(TTFont("_ZodiacUnicode", _fp))
+            _UNICODE_FONT = "_ZodiacUnicode"
+        except Exception:
+            pass
+        break
+
+_ZODIAC_SHORT = [
+    "Ari", "Tau", "Gem", "Can", "Leo", "Vir",
+    "Lib", "Sco", "Sag", "Cap", "Aqu", "Psc",
+]
+_ZODIAC_FULL = [
+    "Aries", "Taurus", "Gemini", "Cancer", "Leo", "Virgo",
+    "Libra", "Scorpius", "Sagittarius", "Capricorn", "Aquarius", "Pisces",
+]
+
+
+class ZodiacWheelSection(Section):
+    """Renders a zodiac wheel showing planet positions as a ReportLab Drawing.
+
+    Args:
+        title:    Section heading.
+        provider: SkyDataProvider instance.
+        date:     Target date (tonight).
+    """
+
+    def __init__(self, title: str, provider: Any, date: datetime) -> None:
+        super().__init__(title)
+        self.provider = provider
+        self.date = date
+
+    # ------------------------------------------------------------------
+    # Section interface
+    # ------------------------------------------------------------------
+
+    def fetch_data(self) -> None:
+        self.data = self.provider.get_sky_data(self.date)
+
+    def has_content(self) -> bool:
+        if self.data is None:
+            self.fetch_data()
+        return bool(self.data and self.data.get("planets"))
+
+    def render(self) -> List[Any]:
+        if self.data is None:
+            self.fetch_data()
+
+        styles = getSampleStyleSheet()
+        elements: List[Any] = []
+        elements.append(Paragraph(self.title, styles["Heading2"]))
+        elements.append(Spacer(1, 4))
+        elements.append(self._build_drawing())
+        return elements
+
+    # ------------------------------------------------------------------
+    # Drawing construction
+    # ------------------------------------------------------------------
+
+    def _build_drawing(self) -> Drawing:
+        cx = cy = _WHEEL_SIZE / 2
+        d = Drawing(_WHEEL_SIZE, _WHEEL_SIZE)
+        d.hAlign = "CENTER"
+
+        sky_data: Dict[str, Any] = cast(Dict[str, Any], self.data) if isinstance(self.data, dict) else {}
+        visible: List[str] = sky_data.get("visible_constellations", [])
+        planets: List[Dict[str, Any]] = sky_data.get("planets", [])
+
+        # Zodiac wedges (ecliptic 0° = Aries at right, grows CCW)
+        for i, (short, full) in enumerate(zip(_ZODIAC_SHORT, _ZODIAC_FULL)):
+            start_deg = i * 30
+            fill = _SIGN_COLORS[i % 2]
+
+            # Annular wedge (outer ring)
+            w = Wedge(cx, cy, _OUTER_R, start_deg, start_deg + 30, radius1=_INNER_R)
+            w.fillColor = fill
+            w.strokeColor = black
+            w.strokeWidth = 0.4
+            d.add(w)
+
+            # Visible overlay (gray tint)
+            if full in visible:
+                overlay = Wedge(cx, cy, _OUTER_R, start_deg, start_deg + 30, radius1=_INNER_R)
+                overlay.fillColor = _VISIBLE_OVERLAY_GRAY
+                overlay.strokeColor = None
+                d.add(overlay)
+
+            # Sign label on rim
+            mid_rad = math.radians(start_deg + 15)
+            lx = cx + _RIM_R * math.cos(mid_rad)
+            ly = cy + _RIM_R * math.sin(mid_rad)
+            d.add(String(lx, ly - 3, short, fontSize=6.5, textAnchor="middle",
+                          fillColor=black))
+
+        # Inner circle border
+        inner_circle = Circle(cx, cy, _INNER_R)
+        inner_circle.fillColor = HexColor("#FFFFFF")
+        inner_circle.strokeColor = black
+        inner_circle.strokeWidth = 0.5
+        d.add(inner_circle)
+
+        # Central dot
+        dot = Circle(cx, cy, 2)
+        dot.fillColor = black
+        dot.strokeColor = None
+        d.add(dot)
+
+        # Planet symbols (astrological Unicode glyphs, or two-letter fallback)
+        for planet in planets:
+            lon_deg = float(planet.get("ecliptic_lon", 0))
+            name = str(planet.get("name", ""))
+            two_letter = str(planet.get("two_letter", name[:2]))
+
+            angle_rad = math.radians(lon_deg)
+            px = cx + _PLANET_R * math.cos(angle_rad)
+            py = cy + _PLANET_R * math.sin(angle_rad)
+
+            symbol = _PLANET_SYMBOLS.get(name, two_letter)
+            font = _UNICODE_FONT if name in _PLANET_SYMBOLS else "Helvetica"
+
+            d.add(String(px, py - 4, symbol, fontSize=10, textAnchor="middle",
+                         fontName=font, fillColor=black))
+
+        return d

--- a/src/screamsheet/sky/__init__.py
+++ b/src/screamsheet/sky/__init__.py
@@ -1,0 +1,4 @@
+"""Sky tonight screamsheet package."""
+from .sky_tonight import SkyTonightScreamsheet
+
+__all__ = ["SkyTonightScreamsheet"]

--- a/src/screamsheet/sky/sky_tonight.py
+++ b/src/screamsheet/sky/sky_tonight.py
@@ -1,0 +1,66 @@
+"""Sky Tonight screamsheet — one-page summary of the naked-eye night sky."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from ..base import BaseScreamsheet, Section
+from ..providers.sky_provider import SkyDataProvider
+from ..renderers.zodiac_wheel import ZodiacWheelSection
+from ..renderers.sky_highlights import SkyHighlightsSection
+
+
+class SkyTonightScreamsheet(BaseScreamsheet):
+    """Generates a one-page PDF summarising tonight's naked-eye sky.
+
+    Sections:
+        1. ZodiacWheelSection  — circular zodiac wheel with planet markers
+        2. SkyHighlightsSection — bulleted highlights + LLM-generated remark
+
+    Args:
+        output_filename: Path for the generated PDF.
+        lat:             Observer latitude (decimal degrees).
+        lon:             Observer longitude (decimal degrees).
+        location_name:   Display name for the observer location.
+        date:            Target date; defaults to *today* (not yesterday).
+    """
+
+    def __init__(
+        self,
+        output_filename: str,
+        lat: float,
+        lon: float,
+        location_name: str,
+        date: Optional[datetime] = None,
+    ) -> None:
+        # Default to *today* — we're describing tonight's sky, not last night's.
+        super().__init__(output_filename, date=date if date is not None else datetime.now())
+        self.lat = lat
+        self.lon = lon
+        self.location_name = location_name
+        self.provider = SkyDataProvider(lat=lat, lon=lon, location_name=location_name)
+
+    # ------------------------------------------------------------------
+    # BaseScreamsheet interface
+    # ------------------------------------------------------------------
+
+    def get_title(self) -> str:
+        return "Sky Tonight Screamsheet"
+
+    def get_subtitle(self) -> Optional[str]:
+        return self.location_name
+
+    def build_sections(self) -> List[Section]:
+        return [
+            ZodiacWheelSection(
+                title="Tonight's Zodiac Wheel",
+                provider=self.provider,
+                date=self.date,
+            ),
+            SkyHighlightsSection(
+                title="Sky Highlights",
+                provider=self.provider,
+                date=self.date,
+                location_name=self.location_name,
+            ),
+        ]

--- a/tests/test_sky_highlights_section.py
+++ b/tests/test_sky_highlights_section.py
@@ -1,0 +1,86 @@
+"""Tests for SkyHighlightsSection."""
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from screamsheet.renderers.sky_highlights import SkyHighlightsSection
+
+
+def _make_provider(highlights=None):
+    provider = MagicMock()
+    provider.get_sky_data.return_value = {
+        "planets": [
+            {"name": "Venus", "zodiac": "Taurus", "ecliptic_lon": 45.0, "two_letter": "Ve"},
+        ],
+        "moon_phase": "Full Moon (100% illuminated)",
+        "highlights": highlights if highlights is not None else [
+            "The Moon is Full Moon (100% illuminated).",
+            "Venus is in Taurus.",
+        ],
+        "visible_constellations": ["Taurus", "Orion"],
+    }
+    return provider
+
+
+class TestSkyHighlightsSectionInit:
+    def test_title_stored(self):
+        s = SkyHighlightsSection("Sky Highlights", _make_provider(), datetime(2026, 4, 18), "Bryn Mawr, PA")
+        assert s.title == "Sky Highlights"
+
+    def test_data_initially_none(self):
+        s = SkyHighlightsSection("Sky Highlights", _make_provider(), datetime(2026, 4, 18), "Bryn Mawr, PA")
+        assert s.data is None
+
+
+class TestSkyHighlightsSectionFetchData:
+    def test_fetch_data_populates_data(self):
+        s = SkyHighlightsSection("Highlights", _make_provider(), datetime(2026, 4, 18), "Test")
+        s.fetch_data()
+        assert s.data is not None
+
+    def test_fetch_data_is_list(self):
+        s = SkyHighlightsSection("Highlights", _make_provider(), datetime(2026, 4, 18), "Test")
+        s.fetch_data()
+        assert isinstance(s.data, list)
+
+    def test_fetch_data_includes_highlights(self):
+        s = SkyHighlightsSection("Highlights", _make_provider(), datetime(2026, 4, 18), "Test")
+        s.fetch_data()
+        assert len(s.data) > 0
+
+
+class TestSkyHighlightsSectionHasContent:
+    def test_true_when_highlights_present(self):
+        s = SkyHighlightsSection("Highlights", _make_provider(), datetime(2026, 4, 18), "Test")
+        assert s.has_content() is True
+
+    def test_false_when_no_highlights(self):
+        s = SkyHighlightsSection("Highlights", _make_provider(highlights=[]), datetime(2026, 4, 18), "Test")
+        assert s.has_content() is False
+
+
+class TestSkyHighlightsSectionRender:
+    def test_render_returns_list(self):
+        s = SkyHighlightsSection("Highlights", _make_provider(), datetime(2026, 4, 18), "Test")
+        result = s.render()
+        assert isinstance(result, list)
+
+    def test_render_returns_non_empty(self):
+        s = SkyHighlightsSection("Highlights", _make_provider(), datetime(2026, 4, 18), "Test")
+        result = s.render()
+        assert len(result) > 0
+
+    def test_render_contains_paragraph(self):
+        from reportlab.platypus import Paragraph
+        s = SkyHighlightsSection("Highlights", _make_provider(), datetime(2026, 4, 18), "Test")
+        result = s.render()
+        paragraphs = [f for f in result if isinstance(f, Paragraph)]
+        assert len(paragraphs) >= 1
+
+    def test_render_graceful_when_no_llm(self):
+        """render() should not raise even when SkyNightSummarizer has no API keys."""
+        s = SkyHighlightsSection("Highlights", _make_provider(), datetime(2026, 4, 18), "Test")
+        # Should not raise
+        result = s.render()
+        assert isinstance(result, list)

--- a/tests/test_sky_night_summarizer.py
+++ b/tests/test_sky_night_summarizer.py
@@ -1,0 +1,55 @@
+"""Unit tests for SkyNightSummarizer."""
+from unittest.mock import patch
+
+from screamsheet.llm.summarizers import SkyNightSummarizer
+
+
+class TestSkyNightSummarizerInit:
+    def test_instantiable_without_api_keys(self):
+        gen = SkyNightSummarizer(gemini_api_key=None, grok_api_key=None)
+        assert gen.llm_gemini is None
+        assert gen.llm_grok is None
+
+
+class TestSkyNightSummarizerPrompt:
+    def _sample_data(self) -> dict:
+        return {
+            "planets": "Venus in Taurus, Mars in Gemini, Jupiter in Gemini",
+            "moon_phase": "Waxing Crescent (35% illuminated)",
+            "highlights": "Venus is in Taurus.\nMars is in Gemini.",
+            "location": "Bryn Mawr, PA",
+            "date": "April 18, 2026",
+        }
+
+    def test_returns_string_without_real_llm(self):
+        gen = SkyNightSummarizer(gemini_api_key=None, grok_api_key=None)
+        result = gen.generate_summary(llm_choice="gemini", data=self._sample_data())
+        assert isinstance(result, str)
+
+    def test_prompt_contains_planet_data(self):
+        gen = SkyNightSummarizer(gemini_api_key=None, grok_api_key=None)
+        prompt = gen._build_llm_prompt(self._sample_data())
+        assert "Venus in Taurus" in prompt
+
+    def test_prompt_contains_moon_phase(self):
+        gen = SkyNightSummarizer(gemini_api_key=None, grok_api_key=None)
+        prompt = gen._build_llm_prompt(self._sample_data())
+        assert "Waxing Crescent" in prompt
+
+    def test_prompt_contains_location(self):
+        gen = SkyNightSummarizer(gemini_api_key=None, grok_api_key=None)
+        prompt = gen._build_llm_prompt(self._sample_data())
+        assert "Bryn Mawr" in prompt
+
+    def test_prompt_contains_date(self):
+        gen = SkyNightSummarizer(gemini_api_key=None, grok_api_key=None)
+        prompt = gen._build_llm_prompt(self._sample_data())
+        assert "April 18, 2026" in prompt
+
+    def test_generate_returns_mocked_summary(self):
+        gen = SkyNightSummarizer(gemini_api_key=None, grok_api_key=None)
+        with patch.object(
+            gen, "_generate_llm_summary", return_value="Venus dazzles tonight!"
+        ):
+            result = gen.generate_summary(llm_choice="gemini", data=self._sample_data())
+        assert result == "Venus dazzles tonight!"

--- a/tests/test_sky_provider.py
+++ b/tests/test_sky_provider.py
@@ -1,0 +1,215 @@
+"""Tests for SkyDataProvider.
+
+Each test verifies exactly one behaviour (SRP).
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from screamsheet.providers.sky_provider import SkyDataProvider
+
+# ---------------------------------------------------------------------------
+# Initialisation
+# ---------------------------------------------------------------------------
+
+class TestSkyDataProviderInit:
+    def test_lat_stored(self):
+        p = SkyDataProvider(lat=40.02, lon=-75.34, location_name="Bryn Mawr, PA")
+        assert p.lat == 40.02
+
+    def test_lon_stored(self):
+        p = SkyDataProvider(lat=40.02, lon=-75.34, location_name="Bryn Mawr, PA")
+        assert p.lon == -75.34
+
+    def test_location_name_stored(self):
+        p = SkyDataProvider(lat=40.02, lon=-75.34, location_name="Bryn Mawr, PA")
+        assert p.location_name == "Bryn Mawr, PA"
+
+
+# ---------------------------------------------------------------------------
+# DataProvider stub overrides
+# ---------------------------------------------------------------------------
+
+class TestSkyDataProviderStubs:
+    def setup_method(self) -> None:
+        self.provider = SkyDataProvider(lat=40.02, lon=-75.34, location_name="Bryn Mawr, PA")
+
+    def test_get_game_scores_returns_empty_list(self):
+        assert self.provider.get_game_scores(datetime(2026, 4, 18)) == []
+
+    def test_get_standings_returns_empty_list(self):
+        assert self.provider.get_standings() == []
+
+
+# ---------------------------------------------------------------------------
+# _ecliptic_lon_to_zodiac  (pure static helper)
+# ---------------------------------------------------------------------------
+
+class TestEclipticLonToZodiac:
+    def setup_method(self) -> None:
+        self.provider = SkyDataProvider(lat=40.02, lon=-75.34, location_name="Bryn Mawr, PA")
+
+    def test_zero_degrees_is_aries(self):
+        assert self.provider._ecliptic_lon_to_zodiac(0.0) == "Aries"
+
+    def test_29_degrees_is_aries(self):
+        assert self.provider._ecliptic_lon_to_zodiac(29.9) == "Aries"
+
+    def test_30_degrees_is_taurus(self):
+        assert self.provider._ecliptic_lon_to_zodiac(30.0) == "Taurus"
+
+    def test_45_degrees_is_taurus(self):
+        assert self.provider._ecliptic_lon_to_zodiac(45.0) == "Taurus"
+
+    def test_75_degrees_is_gemini(self):
+        assert self.provider._ecliptic_lon_to_zodiac(75.0) == "Gemini"
+
+    def test_90_degrees_is_cancer(self):
+        assert self.provider._ecliptic_lon_to_zodiac(90.0) == "Cancer"
+
+    def test_180_degrees_is_libra(self):
+        assert self.provider._ecliptic_lon_to_zodiac(180.0) == "Libra"
+
+    def test_270_degrees_is_capricorn(self):
+        assert self.provider._ecliptic_lon_to_zodiac(270.0) == "Capricorn"
+
+    def test_330_degrees_is_pisces(self):
+        assert self.provider._ecliptic_lon_to_zodiac(330.0) == "Pisces"
+
+    def test_359_degrees_is_pisces(self):
+        assert self.provider._ecliptic_lon_to_zodiac(359.9) == "Pisces"
+
+
+# ---------------------------------------------------------------------------
+# _moon_phase_name  (pure static helper)
+# ---------------------------------------------------------------------------
+
+class TestMoonPhaseName:
+    def setup_method(self) -> None:
+        self.provider = SkyDataProvider(lat=40.02, lon=-75.34, location_name="Test")
+
+    def test_zero_elongation_is_new_moon(self):
+        assert SkyDataProvider._moon_phase_name(0.0) == "New Moon"
+
+    def test_90_elongation_is_first_quarter(self):
+        assert SkyDataProvider._moon_phase_name(90.0) == "First Quarter"
+
+    def test_180_elongation_is_full_moon(self):
+        assert SkyDataProvider._moon_phase_name(180.0) == "Full Moon"
+
+    def test_270_elongation_is_last_quarter(self):
+        assert SkyDataProvider._moon_phase_name(270.0) == "Last Quarter"
+
+    def test_45_elongation_is_waxing_crescent(self):
+        assert SkyDataProvider._moon_phase_name(45.0) == "Waxing Crescent"
+
+    def test_135_elongation_is_waxing_gibbous(self):
+        assert SkyDataProvider._moon_phase_name(135.0) == "Waxing Gibbous"
+
+    def test_225_elongation_is_waning_gibbous(self):
+        assert SkyDataProvider._moon_phase_name(225.0) == "Waning Gibbous"
+
+    def test_315_elongation_is_waning_crescent(self):
+        assert SkyDataProvider._moon_phase_name(315.0) == "Waning Crescent"
+
+
+# ---------------------------------------------------------------------------
+# get_sky_data  (assembly — mocks internal computation methods)
+# ---------------------------------------------------------------------------
+
+class TestGetSkyData:
+    def setup_method(self) -> None:
+        self.provider = SkyDataProvider(lat=40.02, lon=-75.34, location_name="Bryn Mawr, PA")
+        self._date = datetime(2026, 4, 18)
+
+    @patch.object(SkyDataProvider, "_compute_planet_positions")
+    @patch.object(SkyDataProvider, "_compute_moon_phase")
+    @patch.object(SkyDataProvider, "_get_highlights")
+    @patch.object(SkyDataProvider, "_get_visible_constellations")
+    def test_returns_dict(self, mock_vis, mock_hi, mock_moon, mock_planets):
+        mock_planets.return_value = []
+        mock_moon.return_value = "Full Moon (100% illuminated)"
+        mock_hi.return_value = []
+        mock_vis.return_value = []
+        result = self.provider.get_sky_data(self._date)
+        assert isinstance(result, dict)
+
+    @patch.object(SkyDataProvider, "_compute_planet_positions")
+    @patch.object(SkyDataProvider, "_compute_moon_phase")
+    @patch.object(SkyDataProvider, "_get_highlights")
+    @patch.object(SkyDataProvider, "_get_visible_constellations")
+    def test_has_planets_key(self, mock_vis, mock_hi, mock_moon, mock_planets):
+        mock_planets.return_value = [{"name": "Venus"}]
+        mock_moon.return_value = "Waxing Crescent (35% illuminated)"
+        mock_hi.return_value = []
+        mock_vis.return_value = []
+        result = self.provider.get_sky_data(self._date)
+        assert "planets" in result
+
+    @patch.object(SkyDataProvider, "_compute_planet_positions")
+    @patch.object(SkyDataProvider, "_compute_moon_phase")
+    @patch.object(SkyDataProvider, "_get_highlights")
+    @patch.object(SkyDataProvider, "_get_visible_constellations")
+    def test_has_moon_phase_key(self, mock_vis, mock_hi, mock_moon, mock_planets):
+        mock_planets.return_value = []
+        mock_moon.return_value = "Full Moon (100% illuminated)"
+        mock_hi.return_value = []
+        mock_vis.return_value = []
+        result = self.provider.get_sky_data(self._date)
+        assert "moon_phase" in result
+
+    @patch.object(SkyDataProvider, "_compute_planet_positions")
+    @patch.object(SkyDataProvider, "_compute_moon_phase")
+    @patch.object(SkyDataProvider, "_get_highlights")
+    @patch.object(SkyDataProvider, "_get_visible_constellations")
+    def test_has_highlights_key(self, mock_vis, mock_hi, mock_moon, mock_planets):
+        mock_planets.return_value = []
+        mock_moon.return_value = ""
+        mock_hi.return_value = ["Something cool"]
+        mock_vis.return_value = []
+        result = self.provider.get_sky_data(self._date)
+        assert "highlights" in result
+
+    @patch.object(SkyDataProvider, "_compute_planet_positions")
+    @patch.object(SkyDataProvider, "_compute_moon_phase")
+    @patch.object(SkyDataProvider, "_get_highlights")
+    @patch.object(SkyDataProvider, "_get_visible_constellations")
+    def test_has_visible_constellations_key(self, mock_vis, mock_hi, mock_moon, mock_planets):
+        mock_planets.return_value = []
+        mock_moon.return_value = ""
+        mock_hi.return_value = []
+        mock_vis.return_value = ["Orion"]
+        result = self.provider.get_sky_data(self._date)
+        assert "visible_constellations" in result
+
+    @patch.object(SkyDataProvider, "_compute_planet_positions")
+    @patch.object(SkyDataProvider, "_compute_moon_phase")
+    @patch.object(SkyDataProvider, "_get_highlights")
+    @patch.object(SkyDataProvider, "_get_visible_constellations")
+    def test_values_passed_through(self, mock_vis, mock_hi, mock_moon, mock_planets):
+        planets = [{"name": "Mars", "zodiac": "Gemini", "ecliptic_lon": 75.3, "two_letter": "Ma"}]
+        mock_planets.return_value = planets
+        mock_moon.return_value = "First Quarter (50% illuminated)"
+        mock_hi.return_value = ["Mars is high in the east"]
+        mock_vis.return_value = ["Gemini", "Orion"]
+        result = self.provider.get_sky_data(self._date)
+        assert result["planets"] == planets
+        assert result["moon_phase"] == "First Quarter (50% illuminated)"
+        assert result["highlights"] == ["Mars is high in the east"]
+        assert result["visible_constellations"] == ["Gemini", "Orion"]
+
+
+# ---------------------------------------------------------------------------
+# Polar-day / no-dusk edge case
+# ---------------------------------------------------------------------------
+
+class TestPolarEdgeCase:
+    def test_no_dusk_returns_empty_visible_constellations(self):
+        """When _find_astronomical_dusk returns None (polar day/night), no crash."""
+        provider = SkyDataProvider(lat=90.0, lon=0.0, location_name="North Pole")
+        with patch.object(provider, "_find_astronomical_dusk", return_value=None):
+            result = provider._get_visible_constellations(datetime(2026, 4, 18), None)
+        assert result == []

--- a/tests/test_sky_tonight_screamsheet.py
+++ b/tests/test_sky_tonight_screamsheet.py
@@ -1,0 +1,98 @@
+"""Tests for SkyTonightScreamsheet and factory method."""
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from screamsheet.sky.sky_tonight import SkyTonightScreamsheet
+from screamsheet.factory import ScreamsheetFactory
+from screamsheet.renderers.zodiac_wheel import ZodiacWheelSection
+from screamsheet.renderers.sky_highlights import SkyHighlightsSection
+
+
+class TestSkyTonightScreamshetInit:
+    def test_output_filename_stored(self):
+        s = SkyTonightScreamsheet("out.pdf", lat=40.0, lon=-75.0, location_name="Test")
+        assert s.output_filename == "out.pdf"
+
+    def test_lat_stored(self):
+        s = SkyTonightScreamsheet("out.pdf", lat=40.0, lon=-75.0, location_name="Test")
+        assert s.lat == 40.0
+
+    def test_lon_stored(self):
+        s = SkyTonightScreamsheet("out.pdf", lat=40.0, lon=-75.0, location_name="Test")
+        assert s.lon == -75.0
+
+    def test_location_name_stored(self):
+        s = SkyTonightScreamsheet("out.pdf", lat=40.0, lon=-75.0, location_name="Bryn Mawr")
+        assert s.location_name == "Bryn Mawr"
+
+    def test_default_date_is_today(self):
+        before = datetime.now()
+        s = SkyTonightScreamsheet("out.pdf", lat=40.0, lon=-75.0, location_name="Test")
+        after = datetime.now()
+        assert before <= s.date <= after
+
+    def test_explicit_date_used(self):
+        d = datetime(2026, 4, 18)
+        s = SkyTonightScreamsheet("out.pdf", lat=40.0, lon=-75.0, location_name="Test", date=d)
+        assert s.date == d
+
+
+class TestSkyTonightScreamshetTitle:
+    def test_get_title(self):
+        s = SkyTonightScreamsheet("out.pdf", lat=40.0, lon=-75.0, location_name="Test")
+        assert s.get_title() == "Sky Tonight Screamsheet"
+
+
+class TestSkyTonightScreamshetSections:
+    def setup_method(self) -> None:
+        self.sheet = SkyTonightScreamsheet(
+            "out.pdf", lat=40.0, lon=-75.0, location_name="Test",
+            date=datetime(2026, 4, 18),
+        )
+
+    def test_build_sections_returns_list(self):
+        sections = self.sheet.build_sections()
+        assert isinstance(sections, list)
+
+    def test_build_sections_has_two_sections(self):
+        sections = self.sheet.build_sections()
+        assert len(sections) == 2
+
+    def test_first_section_is_zodiac_wheel(self):
+        sections = self.sheet.build_sections()
+        assert isinstance(sections[0], ZodiacWheelSection)
+
+    def test_second_section_is_sky_highlights(self):
+        sections = self.sheet.build_sections()
+        assert isinstance(sections[1], SkyHighlightsSection)
+
+
+class TestScreamsheetFactorySkyTonight:
+    def test_returns_sky_tonight_instance(self):
+        s = ScreamsheetFactory.create_sky_tonight_screamsheet(
+            "out.pdf", lat=40.0, lon=-75.0, location_name="Test"
+        )
+        assert isinstance(s, SkyTonightScreamsheet)
+
+    def test_output_filename_passed(self):
+        s = ScreamsheetFactory.create_sky_tonight_screamsheet(
+            "sky.pdf", lat=40.0, lon=-75.0, location_name="Test"
+        )
+        assert s.output_filename == "sky.pdf"
+
+    def test_lat_lon_passed(self):
+        s = ScreamsheetFactory.create_sky_tonight_screamsheet(
+            "out.pdf", lat=51.5, lon=-0.1, location_name="London"
+        )
+        assert s.lat == 51.5
+        assert s.lon == -0.1
+
+    def test_explicit_date_passed(self):
+        d = datetime(2026, 6, 21)
+        s = ScreamsheetFactory.create_sky_tonight_screamsheet(
+            "out.pdf", lat=40.0, lon=-75.0, location_name="Test", date=d
+        )
+        assert s.date == d

--- a/tests/test_zodiac_wheel_section.py
+++ b/tests/test_zodiac_wheel_section.py
@@ -1,0 +1,83 @@
+"""Tests for ZodiacWheelSection."""
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from screamsheet.renderers.zodiac_wheel import ZodiacWheelSection
+
+
+def _make_provider(planets=None):
+    provider = MagicMock()
+    if planets is None:
+        planets = [
+            {"name": "Venus", "zodiac": "Taurus", "ecliptic_lon": 45.0, "two_letter": "Ve"},
+            {"name": "Mars", "zodiac": "Gemini", "ecliptic_lon": 75.0, "two_letter": "Ma"},
+        ]
+    provider.get_sky_data.return_value = {
+        "planets": planets,
+        "moon_phase": "Waxing Crescent (35% illuminated)",
+        "highlights": [],
+        "visible_constellations": ["Taurus", "Gemini"],
+    }
+    return provider
+
+
+class TestZodiacWheelSectionInit:
+    def test_title_stored(self):
+        s = ZodiacWheelSection("Tonight's Wheel", _make_provider(), datetime(2026, 4, 18))
+        assert s.title == "Tonight's Wheel"
+
+    def test_data_initially_none(self):
+        s = ZodiacWheelSection("Wheel", _make_provider(), datetime(2026, 4, 18))
+        assert s.data is None
+
+
+class TestZodiacWheelSectionFetchData:
+    def test_fetch_data_populates_data(self):
+        s = ZodiacWheelSection("Wheel", _make_provider(), datetime(2026, 4, 18))
+        s.fetch_data()
+        assert s.data is not None
+
+    def test_fetch_data_contains_planets(self):
+        s = ZodiacWheelSection("Wheel", _make_provider(), datetime(2026, 4, 18))
+        s.fetch_data()
+        assert isinstance(s.data, dict)
+        assert "planets" in s.data
+
+    def test_fetch_data_contains_visible_constellations(self):
+        s = ZodiacWheelSection("Wheel", _make_provider(), datetime(2026, 4, 18))
+        s.fetch_data()
+        assert "visible_constellations" in s.data
+
+
+class TestZodiacWheelSectionHasContent:
+    def test_true_when_planets_present(self):
+        s = ZodiacWheelSection("Wheel", _make_provider(), datetime(2026, 4, 18))
+        assert s.has_content() is True
+
+    def test_false_when_no_planets(self):
+        provider = _make_provider(planets=[])
+        s = ZodiacWheelSection("Wheel", provider, datetime(2026, 4, 18))
+        assert s.has_content() is False
+
+
+class TestZodiacWheelSectionRender:
+    def test_render_returns_non_empty_list(self):
+        s = ZodiacWheelSection("Wheel", _make_provider(), datetime(2026, 4, 18))
+        result = s.render()
+        assert len(result) > 0
+
+    def test_render_returns_list(self):
+        s = ZodiacWheelSection("Wheel", _make_provider(), datetime(2026, 4, 18))
+        result = s.render()
+        assert isinstance(result, list)
+
+    def test_render_contains_drawing(self):
+        from reportlab.graphics.shapes import Drawing
+        s = ZodiacWheelSection("Wheel", _make_provider(), datetime(2026, 4, 18))
+        flowables = s.render()
+        drawing_types = [f for f in flowables if isinstance(f, Drawing)]
+        assert len(drawing_types) >= 1

--- a/uv.lock
+++ b/uv.lock
@@ -906,6 +906,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jplephem"
+version = "2.24"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/8b/a50514f000fcd0207cd281370b0db66e7712a5db9f96b77a0301a7205f96/jplephem-2.24.tar.gz", hash = "sha256:354fe1adae022264ab46f18afb6af26211277cfd7b3ef90400755fcabe93bc11", size = 45289, upload-time = "2026-01-23T21:03:01.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/3f/b9d5739352badc11ca637c8f72525d519458622936bc3313ddefdc7dee96/jplephem-2.24-py3-none-any.whl", hash = "sha256:2de15608a0f13010a71a0a8af8765646d5884402006dac0dd7639d7db13629ac", size = 49585, upload-time = "2026-01-23T21:03:00.079Z" },
+]
+
+[[package]]
 name = "jsonpatch"
 version = "1.33"
 source = { registry = "https://pypi.org/simple" }
@@ -2362,6 +2374,7 @@ dependencies = [
     { name = "setuptools" },
     { name = "sgmllib3k" },
     { name = "six" },
+    { name = "skyfield" },
     { name = "sniffio" },
     { name = "sqlalchemy" },
     { name = "tenacity" },
@@ -2471,6 +2484,7 @@ requires-dist = [
     { name = "setuptools", specifier = "==80.9.0" },
     { name = "sgmllib3k", specifier = "==1.0.0" },
     { name = "six", specifier = "==1.17.0" },
+    { name = "skyfield", specifier = ">=1.48" },
     { name = "sniffio", specifier = "==1.3.1" },
     { name = "sqlalchemy", specifier = "==2.0.44" },
     { name = "tenacity", specifier = "==9.1.2" },
@@ -2506,12 +2520,63 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
 
 [[package]]
+name = "sgp4"
+version = "2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/d0/fc467010d17742321f73b16a71acac88439a88f2b166641942a6566c9b2a/sgp4-2.25.tar.gz", hash = "sha256:e19edc6dcc25d69fb8fde0a267b8f0c44d7e915c7bcbeacf5d3a8b595baf0674", size = 181016, upload-time = "2025-08-04T18:02:33.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/86/f329af1f37f88693a7e8db92f9c0bf92a7e7dc44c272f89a2808b0582766/sgp4-2.25-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:29fd9ad2ded9517f6ba10f91e2d993144400c6a925e2b7931198646625beafd4", size = 162967, upload-time = "2025-08-04T18:01:39.296Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f0/c258a86bf9f50b46295bdc32af15954719ba88a12267572f7123ffc66f0d/sgp4-2.25-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9ad88a8ced4b78f337765e8463f7f11c5f86d9267f83fc8e3dd8982df67bff45", size = 161934, upload-time = "2025-08-04T18:01:40.99Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/4f/f437ca8daaba0e3c4ce67a997f30eead0489908527d6b358418ed4a3e8b1/sgp4-2.25-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc0c6ccb0f83e670e50dcd8a90b8a5bfe5bbf4225ce8450f807e14acc517ab21", size = 235757, upload-time = "2025-08-04T18:01:42.164Z" },
+    { url = "https://files.pythonhosted.org/packages/29/19/e8f990fc80d508e7957f9b621366db05d384f5af70d05f77376be74e3007/sgp4-2.25-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3282ec0931e57692f3bf875342f28f41b1155cb575cbe24a30c3cd272ea46fb5", size = 232737, upload-time = "2025-08-04T18:01:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/26/e3/898d7a6d31309cb1be2b2b68dd14141da300ee7257bc30774759a9c1a323/sgp4-2.25-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18e44f66670c61ae2372d6fecde076cb655f76d211b34b8de440cad5a273409f", size = 235207, upload-time = "2025-08-04T18:01:44.532Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c2/bb42e252846d29f668ff26b42adf65c842c8985c033b58d61d1c810728aa/sgp4-2.25-cp310-cp310-win32.whl", hash = "sha256:a2cc50b72b7d2b04c4012b492ec0e76f085e84de45f5e56d3baa4d3ef5f65dac", size = 161870, upload-time = "2025-08-04T18:01:45.461Z" },
+    { url = "https://files.pythonhosted.org/packages/23/e8/3e44b47d3ccab7ae02a03d8107651c080da671a0c6e49cb97dd953f10809/sgp4-2.25-cp310-cp310-win_amd64.whl", hash = "sha256:2b92506eef5c07063ab7595db58373bd965f8969fb1fb5b76cbffeb39027ba93", size = 164101, upload-time = "2025-08-04T18:01:46.439Z" },
+    { url = "https://files.pythonhosted.org/packages/03/1c/388f1b70a637e3bee179fae1031dcdd8ce09bd040bbbe80fcba20a2e2b86/sgp4-2.25-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:93b22b9ae35db33664f2ddc37955a8d86c3a28f5c668d201e8c6f195a184496f", size = 162964, upload-time = "2025-08-04T18:01:47.866Z" },
+    { url = "https://files.pythonhosted.org/packages/47/42/7f27ceca4730d2af31b20928b1c0f1f924cd942c2709d11fc52d9e02f48e/sgp4-2.25-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:33048ff064a4c0b6d8e3c2c79449a49ff45f5dabe8594622f0fb7ed17fa27c0e", size = 161937, upload-time = "2025-08-04T18:01:48.951Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/9f/99b1587bd3e6c17405efbd9e48603ae194c9d53938e1f8946c6c5d18c33f/sgp4-2.25-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac94f1d6fae120beeb40f2af587b351f9cb198837ae0fb3678e3bce44334a2a2", size = 235730, upload-time = "2025-08-04T18:01:49.905Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/5a/76f56a0466c3a916403b320363a0f10e71db5a34d2b3627d6a92d2eb9d08/sgp4-2.25-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1b164e636c4f1c64e09c6164b85985395c28c8556bc72ea56e42a889826287a0", size = 232736, upload-time = "2025-08-04T18:01:50.973Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f8/c1216d3c85341e30d79c9ca27b2c27dba6ed0238c56e8b04ef568ea92c50/sgp4-2.25-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfaddc20c4d6aa2e86119d13e3fd94a1d05e5bd17cb4fddb2ca5116842bc9228", size = 235203, upload-time = "2025-08-04T18:01:52.275Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c6/846a8039a0e8c5b653265e0248ee9836c75f420cfe99a65215a23f035595/sgp4-2.25-cp311-cp311-win32.whl", hash = "sha256:0ecd7d8833f83fe426d7926149665f4f23f4dab34b844e50876a1df88ee9aa7b", size = 161868, upload-time = "2025-08-04T18:01:53.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ff/a74904468464d01dd52affb4b15ee1fe5ea804e5128a3f5f5f38c954765d/sgp4-2.25-cp311-cp311-win_amd64.whl", hash = "sha256:6b023f81fb20e62f8fa0b6f506201539ca8306779ef8565422bbf000f1e5a3dc", size = 164096, upload-time = "2025-08-04T18:01:54.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/71/864524bde46a02e636cc5de47b9a4e1f1ed18c7acc3f1319cf9fe1db3c7a/sgp4-2.25-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:170ec2882cd166ff9d8dccfb8018f86d5cc033ea8a07c27a1825999c62439f05", size = 162985, upload-time = "2025-08-04T18:01:55.646Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cd/022aa419d9570d494dafd5103a71dda64c6ffc956a1c7f5b096a58a23a6a/sgp4-2.25-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:64c7597a60b770caac51566b1f621d1cd74df0409ef19c5e7ea3505d0dfbc677", size = 161951, upload-time = "2025-08-04T18:01:56.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/1c/76dbf2190d30a770fe8ac57474d212e005f56f47e65dd6fcecdb546d454f/sgp4-2.25-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e1d18b8972643dd29e758e67c062cfb68fbe2421fe3f6398f1957a9825119f6", size = 236340, upload-time = "2025-08-04T18:01:57.778Z" },
+    { url = "https://files.pythonhosted.org/packages/97/a4/2fc9bf9cb75571222bd453407317e91193a3db1c559333c5e46ce7a014c9/sgp4-2.25-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:35649388a06cbee7def24cbb789f452c31d42ed9e87bddd89935ed78f19451ed", size = 233080, upload-time = "2025-08-04T18:01:58.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/40/50ecdc518edd3a85ad74bda7a2196b53d5901256e3d7ab34225c96e8edc8/sgp4-2.25-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:911460477f1c52dcda2b3eb20538435b89b0a43668bcb5edd1e7700b7a1a0225", size = 235729, upload-time = "2025-08-04T18:01:59.83Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/dd/c1ee8571828debfd3e0f2297379a2a2af75024062c70cf76bdc121e77623/sgp4-2.25-cp312-cp312-win32.whl", hash = "sha256:128edd3d6061e833600d93e77d4c08d1a5002293997e368256b0b777ea525dda", size = 161899, upload-time = "2025-08-04T18:02:00.882Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f8/7dae15af520dfe5def1f8620c2817203cbbf1a1bf154b2079add1200acd3/sgp4-2.25-cp312-cp312-win_amd64.whl", hash = "sha256:979eb60e74aff5dc318cfe1a6c817db884486bdfc8496d2c5bc07b05fe833280", size = 164137, upload-time = "2025-08-04T18:02:01.817Z" },
+    { url = "https://files.pythonhosted.org/packages/02/0f/daf4a70829be7c1550b914c98b3abbd15404d00899835432ae8d4a9be502/sgp4-2.25-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c4d4eab0f2c94aad3a0ab0bedd59f2137484af5480a3b40df8e4ab5a1fbc6b86", size = 162974, upload-time = "2025-08-04T18:02:02.816Z" },
+    { url = "https://files.pythonhosted.org/packages/27/88/af20e342590c3ede18cc8dc6a1e1da708f576e1a97dcb69e2870e739ae21/sgp4-2.25-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2822ca25f3724694bfced16cad8b3018678bee47fa3baf4eea20876d0e35ad33", size = 161957, upload-time = "2025-08-04T18:02:03.835Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/14/81f0df0cc39bdc95336a6f5834c84a6e5f79b5e728918cb9dadff3278017/sgp4-2.25-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7beca36492eb6d20ef15eeedd9520b8af4fa0cbaaae46a9269d5a2e7c8e56e46", size = 236195, upload-time = "2025-08-04T18:02:05.121Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/a7/3740791f656d9b7ad78da7c0d9f6f842a18642fead2d26b2d69fb701892e/sgp4-2.25-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8e9dfd18cacf6bfb1faad29c89a6cec98a642558f805851080dea9c394520db2", size = 232992, upload-time = "2025-08-04T18:02:06.086Z" },
+    { url = "https://files.pythonhosted.org/packages/62/45/0e35398ef8d4b07ecfa9f7f680e183b2b6af9215a56af34f9e621c29b495/sgp4-2.25-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5789b7add136362684dfcbf0862919f8c3018f74ab11a05a9964edd5fdd4d2a7", size = 235584, upload-time = "2025-08-04T18:02:07.152Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b7/1b680b5514586b3860500109ef37fd1761f21e6787f20a2597baa44d91a0/sgp4-2.25-cp313-cp313-win32.whl", hash = "sha256:94219b486def29aa1246f42de8bea05ccb8e98a5458dd08ce42b9811c79ca814", size = 161896, upload-time = "2025-08-04T18:02:08.062Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c1/a22be2e7886db40d1512969f3b8cc3ce989167e69ea8f308f26afd1dfd31/sgp4-2.25-cp313-cp313-win_amd64.whl", hash = "sha256:dec2f6c842d9bf40c67d5764bd752980844f91f338020d2af7f85847364d0ff7", size = 164142, upload-time = "2025-08-04T18:02:09Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "skyfield"
+version = "1.54"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "jplephem" },
+    { name = "numpy" },
+    { name = "sgp4" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/8c/98bf5d9042218580fc10c4ba0c51b9af26bc73b614ce64341c0dfad39074/skyfield-1.54.tar.gz", hash = "sha256:bf8b79d6dbbe1add0327aca485d6388bb6a13cab70528d015913a9b07a1d6903", size = 346829, upload-time = "2026-01-18T19:16:15.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/8a/f196038b2bea40c372d900803dac0d5e4eab578cb05b92ff7172ced4c1cf/skyfield-1.54-py3-none-any.whl", hash = "sha256:c9b313185448963ea7fa4cf8e4298ba028b179b80ebd4c5675497519f21c04a2", size = 370380, upload-time = "2026-01-18T19:16:13.806Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add SkyDataProvider using skyfield DE421 ephemeris for planet ecliptic positions, moon phase, conjunction detection, and constellation visibility at astronomical dusk
- Add ZodiacWheelSection: full circular wheel with 12 annular wedges, planet markers, and visible-sky shading
- Add SkyHighlightsSection: bulleted sky highlights with optional LLM-generated astronomy/astrology bullet via SkyNightSummarizer
- Add SkyTonightScreamsheet and ScreamsheetFactory.create_sky_tonight_screamsheet()
- Wire into __main__.py; add sky: config block to config.yaml.example
- 73 new tests, 0 regressions