### PR TITLE
feat(sky): add Swiss Ephemeris horoscope pipeline with Hellenistic fr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,41 @@ The `db_update` CLI command is already wired in `[project.scripts]`:
 [project.scripts]
 db_update = "screamsheet.db.db_update:main"
 ```
+
+---
+
+## Sky Tonight — Horoscope Pipeline (Issue #66)
+
+The Sky Tonight screamsheet uses **two separate astronomy libraries** for different purposes:
+
+| Concern | Library | Provider |
+|---|---|---|
+| Zodiac wheel visual, constellation visibility, sky highlights | Skyfield (DE421) | `SkyDataProvider` |
+| Horoscope planet positions, planetary aspects, moon phase | Swiss Ephemeris (Moshier) | `AstroDataProvider` |
+
+### `AstroDataProvider`
+
+Located at `src/screamsheet/providers/astro_provider.py`.  Uses [`pyswisseph`](https://pypi.org/project/pyswisseph/) with the Moshier built-in ephemeris — **no data file downloads required**.
+
+Key methods:
+
+| Method | Returns | Description |
+|---|---|---|
+| `get_planet_longitudes(date)` | `List[Dict]` | Tropical ecliptic longitude for 9 planets (Sun–Neptune) anchored to the vernal equinox |
+| `get_aspects(date)` | `List[Dict]` | All major aspects (conjunction, sextile, square, trine, opposition) with standard orbs |
+| `get_moon_phase(date)` | `str` | Phase name derived from Sun–Moon elongation |
+| `get_horoscope_data(date)` | `Dict` | Combined dict with `planets`, `aspects`, `moon_phase` |
+
+### Planetary aspects
+
+Five major aspects are computed for all pairs of the 9 modern planets:
+
+| Aspect | Angle | Orb |
+|---|---|---|
+| Conjunction | 0° | ±8° |
+| Sextile | 60° | ±6° |
+| Square | 90° | ±8° |
+| Trine | 120° | ±8° |
+| Opposition | 180° | ±8° |
+
+The aspects list is passed to the horoscope LLM prompt via the `{aspects}` template variable.

--- a/documentation/sky-tonight/ISSUE_66_SEPARATE_HOROSCOPE.md
+++ b/documentation/sky-tonight/ISSUE_66_SEPARATE_HOROSCOPE.md
@@ -1,0 +1,31 @@
+# Refactor Horoscope Pipeline: Use Swiss Ephemeris for Zodiac Sector Calculation and Aspect Analysis 
+
+## Background
+Currently, the Sky Tonight screamsheet uses Skyfield to calculate planetary positions both for the visual Zodiac circle (front page) and for generating horoscopes (LLM summaries). For naked-eye and constellation-based representations, Skyfield remains suitable. However, horoscopes require positions anchored to the vernal equinox (astrological degrees, not current constellation boundaries), which has shifted considerably over millennia. Additionally, astrological analysis requires calculation of planetary aspects (angles between planets) in addition to absolute positions.
+
+## Requirements
+- **Replace planetary position calculations for horoscopes:**
+  - Use [PySwissEph](https://pypi.org/project/pyswisseph/) (Swiss Ephemeris Python bindings) instead of Skyfield for calculating astrological planetary longitudes.
+  - Compute each planet's position as the number of degrees from the vernal equinox (Aries 0°), dividing the ecliptic into 12 equal sectors.
+  - Provide this data for both daily horoscopes (LLM input) and any technical/verification output.
+  
+- **Calculate and provide planetary aspects:**
+  - Compute all major astrological aspects between relevant planetary bodies (e.g., conjunction, opposition, square, trine, sextile, etc.).
+  - Present aspect data in a machine-readable form for LLM consumption.
+
+- **Maintain Current "Sky Tonight" Visuals:**
+  - Continue rendering the naked-eye sky map (Zodiac circle, constellation assignment, and Horkheimer-style LLM summary) using Skyfield as before.
+
+## Acceptance Criteria
+- Horoscopes and aspects are based entirely on Swiss Ephemeris calculations, **not** Skyfield.
+- Zodiac constellation graphics and written sky summary remain Skyfield-based.
+- Data pipeline for horoscopes supplies LLM with: (1) planet positions in zodiac sectors from vernal equinox, and (2) complete aspects table.
+- All new or changed modules fully typed (mypy clean), tested (TDD), and described in README.md.
+
+## References
+- [Swiss Ephemeris Documentation](https://www.astro.com/swisseph/)
+- [PySwissEph PyPI](https://pypi.org/project/pyswisseph/)
+- [Astrological aspect basics](https://en.wikipedia.org/wiki/Astrological_aspect)
+
+---
+**Housekeeping:** Issue-driven, TDD and SRP strictly enforced. Commit message MUST reference this issue number.

--- a/mypy.ini
+++ b/mypy.ini
@@ -17,3 +17,6 @@ ignore_missing_imports = True
 
 [mypy-skyfield.*]
 ignore_missing_imports = True
+
+[mypy-swisseph]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,8 +118,14 @@ dependencies = [
     "yarl==1.22.0",
     "zstandard==0.25.0",
     "skyfield>=1.48",
+    "pyswisseph>=2.10.3.2",
 ]
 
 [project.scripts]
 db_update    = "screamsheet.db.db_update:main"
 show_prompt  = "screamsheet.tools.show_prompt:main"
+
+[dependency-groups]
+dev = [
+    "mypy>=1.20.2",
+]

--- a/src/screamsheet/llm/prompts/sky_horoscope.txt
+++ b/src/screamsheet/llm/prompts/sky_horoscope.txt
@@ -1,14 +1,22 @@
-You are a thoughtful astrologer writing a personalized daily horoscope for a print newsletter.
+You are a high-level strategic advisor, modeled after Johannes Kepler. Your frame of reference is Hellenistic and mathematical astrology. You treat the planetary geometry as a system of "Celestial Mechanics" that dictates the timing of successful action.
 
-Write a horoscope reading for {name}, born on {birth_date} at {birth_time} in {birth_location}.
-Natal chart: Sun in {sun_sign}, Moon in {moon_sign}, {ascendant} rising.
-Tonight's date is {date}, observed from {location}.
+The Strategy: Do not offer platitudes. Identify the "Critical Path" of the day. Use the Dignity (strength) and Aspects (friction/support) of the planets to tell the subject exactly how to navigate their specific "Houses" (areas of life).
 
-Current planetary positions: {planets}
-Moon phase: {moon_phase}
+Subject: {name}, born {birth_date} at {birth_time} in {birth_location}.
+Today's date: {date}, observed from {location}.
 
-Begin by briefly reminding the reader of their Sun in {sun_sign}, Moon in {moon_sign}, and {ascendant} ascendant. Then write the horoscope reading. Keep the whole thing under 200 words of plain text (no Markdown or other formatting). Speak directly to the person using "you" and "your." Ground the reading in tonight's actual planetary positions — reference specific planets and signs where relevant. Be warm, specific, and honest — do not be vague or generic. No closing sign-off.
+NATAL CHART:
+{subject_natal}
 
-In the horoscope, clearly mention the person's natal Sun sign, natal Moon sign, and natal Ascendant (Rising sign) early in the reading, based on their birth data.
+CURRENT SKY (transits):
+{current_sky}
 
-No preamble, no sign label header, no closing sign-off. Start directly with the reading.
+**Writing Rules:**
+1. **The Opening:** One fluid, elegant sentence acknowledging the subject's Sun, Moon, and Ascendant.  Be explicit about the birth zodiac locations here.
+2. **The Strategic Assessment:** Identify the most powerful planet (the "Engine") and the most compromised planet (the "Friction"). 
+3. **The Keplerian Directive:** Provide clear, imperative commands. Use the logic: "Because the geometry shows [X], you must avoid [Y] and instead execute [Z]." 
+4. **House-Grounded Advice:** The advice must be specific to the House meanings. If the friction is in the 5th House, talk about creative risk or children. If the support is in the 7th, talk about contracts or the spouse.
+5. **Sophisticated Lexicon:** Use terms like *architecture*, *geometry*, *momentum*, *stasis*, and *rectification*. Only use technical terms like *Domicile* or *Square* to justify a specific tactical pivot.
+6. **The Harmonic Synthesis:** Instead of treating each planet as a separate item, describe the **Aspects** as 'chords' or 'dissonances.' If a planet is 'Square' another, describe it as 'geometric friction' that requires 'resolution.' This elevates the reading from a list to a system-wide analysis.
+7. **Tone:** Authoritative, sophisticated, and insightful. Speak as a trusted advisor to a sovereign.
+8. **Constraint:** Under 200 words. Plain text only. No Markdown, no headers, no preamble, no sign-off.

--- a/src/screamsheet/llm/prompts/sky_tonight.txt
+++ b/src/screamsheet/llm/prompts/sky_tonight.txt
@@ -12,4 +12,4 @@ Highlights:
 
 Write a short, lively "The Sky Tonight" description in the classic Star Hustler style — warm, inviting, and under 200 words. Start with an enthusiastic greeting, describe the best naked-eye sights (Moon, bright planets, conjunctions, meteor shower), weave in 1–2 fun asides, tell the observer exactly where and when to look, and end with an encouraging sign-off like "So get outside, and keep looking up!"
 
-Output ONLY the paragraph(s) in that enthusiastic voice. No bullet points, no extra explanations, and no formatting or Markdown.
+Output ONLY the paragraph(s) in that enthusiastic voice. No extra explanations, no formatting, no Markdown.

--- a/src/screamsheet/providers/astro_provider.py
+++ b/src/screamsheet/providers/astro_provider.py
@@ -1,0 +1,355 @@
+"""Astrological data provider using Swiss Ephemeris (pyswisseph).
+
+Computes planet positions anchored to the vernal equinox (tropical zodiac),
+planetary aspects, and moon phase for horoscope generation.  Uses the
+Moshier built-in ephemeris — no external data files are required.
+"""
+from __future__ import annotations
+
+import math
+from datetime import datetime
+from typing import Any, Dict, List
+
+import swisseph as swe  # type: ignore[import-untyped]
+
+from ..base.data_provider import DataProvider
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_ZODIAC_SIGNS = [
+    "Aries", "Taurus", "Gemini", "Cancer", "Leo", "Virgo",
+    "Libra", "Scorpio", "Sagittarius", "Capricorn", "Aquarius", "Pisces",
+]
+
+# Swiss Ephemeris planet IDs
+_PLANET_IDS: Dict[str, int] = {
+    "Sun":     swe.SUN,
+    "Moon":    swe.MOON,
+    "Mercury": swe.MERCURY,
+    "Venus":   swe.VENUS,
+    "Mars":    swe.MARS,
+    "Jupiter": swe.JUPITER,
+    "Saturn":  swe.SATURN,
+    "Uranus":  swe.URANUS,
+    "Neptune": swe.NEPTUNE,
+}
+
+# Two-letter abbreviations for display
+_PLANET_TWO_LETTER: Dict[str, str] = {
+    "Sun":     "Su",
+    "Moon":    "Mo",
+    "Mercury": "Me",
+    "Venus":   "Ve",
+    "Mars":    "Ma",
+    "Jupiter": "Ju",
+    "Saturn":  "Sa",
+    "Uranus":  "Ur",
+    "Neptune": "Ne",
+}
+
+# Major astrological aspects: (angle_degrees, orb_degrees, name)
+_ASPECTS = [
+    (0.0,   8.0, "Conjunction"),
+    (60.0,  6.0, "Sextile"),
+    (90.0,  8.0, "Square"),
+    (120.0, 8.0, "Trine"),
+    (180.0, 8.0, "Opposition"),
+]
+
+# Whole-sign house meanings (Hellenistic tradition)
+_HOUSE_MEANINGS: Dict[int, str] = {
+    1:  "Identity/Physical Self",
+    2:  "Finances/Resources",
+    3:  "Communication/Siblings",
+    4:  "Home/Family Roots",
+    5:  "Creativity/Pleasure",
+    6:  "Daily Routine/Health",
+    7:  "Partnerships/Open Enemies",
+    8:  "Transformation/Shared Resources",
+    9:  "Philosophy/Higher Learning",
+    10: "Career/Public Reputation",
+    11: "Community/Friendships",
+    12: "Hidden Matters/Undoing",
+}
+
+# Traditional planetary dignities (Hellenistic + modern outer planets)
+_DIGNITY_TABLE: Dict[str, Dict[str, List[str]]] = {
+    "Sun":     {"domicile": ["Leo"],                    "exaltation": ["Aries"],     "detriment": ["Aquarius"],              "fall": ["Libra"]},
+    "Moon":    {"domicile": ["Cancer"],                 "exaltation": ["Taurus"],    "detriment": ["Capricorn"],             "fall": ["Scorpio"]},
+    "Mercury": {"domicile": ["Gemini", "Virgo"],        "exaltation": ["Virgo"],     "detriment": ["Sagittarius", "Pisces"], "fall": ["Pisces"]},
+    "Venus":   {"domicile": ["Taurus", "Libra"],        "exaltation": ["Pisces"],    "detriment": ["Aries", "Scorpio"],      "fall": ["Virgo"]},
+    "Mars":    {"domicile": ["Aries", "Scorpio"],       "exaltation": ["Capricorn"], "detriment": ["Taurus", "Libra"],       "fall": ["Cancer"]},
+    "Jupiter": {"domicile": ["Sagittarius", "Pisces"],  "exaltation": ["Cancer"],    "detriment": ["Gemini", "Virgo"],       "fall": ["Capricorn"]},
+    "Saturn":  {"domicile": ["Capricorn", "Aquarius"],  "exaltation": ["Libra"],     "detriment": ["Cancer", "Leo"],         "fall": ["Aries"]},
+    "Uranus":  {"domicile": ["Aquarius"],               "exaltation": [],            "detriment": ["Leo"],                   "fall": []},
+    "Neptune": {"domicile": ["Pisces"],                 "exaltation": [],            "detriment": ["Virgo"],                 "fall": []},
+}
+
+
+class AstroDataProvider(DataProvider):
+    """Provides astrological data using Swiss Ephemeris (Moshier built-in ephemeris).
+
+    Calculates tropical zodiac positions (from the vernal equinox), planetary
+    aspects, and moon phase.  All calculations observe at 22:00 UTC as a
+    consistent 'tonight' proxy matching the existing SkyDataProvider convention.
+    """
+
+    # ------------------------------------------------------------------
+    # DataProvider interface stubs (not applicable for astrological data)
+    # ------------------------------------------------------------------
+
+    def get_game_scores(self, date: datetime) -> list:
+        return []
+
+    def get_standings(self) -> list:
+        return []
+
+    # ------------------------------------------------------------------
+    # Pure static helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _ecliptic_lon_to_zodiac(lon_deg: float) -> str:
+        """Map a tropical ecliptic longitude (0–360°) to a zodiac sign name."""
+        idx = int(lon_deg / 30) % 12
+        return _ZODIAC_SIGNS[idx]
+
+    @staticmethod
+    def _get_julian_day(date: datetime) -> float:
+        """Return the Julian Day number for 22:00 UTC on *date*."""
+        return swe.julday(date.year, date.month, date.day, 22.0)
+
+    @staticmethod
+    def _angular_difference(lon_a: float, lon_b: float) -> float:
+        """Return the smallest positive angle between two ecliptic longitudes (0–180°)."""
+        diff = abs(lon_a - lon_b) % 360.0
+        if diff > 180.0:
+            diff = 360.0 - diff
+        return diff
+
+    @staticmethod
+    def _compute_aspects(planets: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Return all major aspects between planet pairs.
+
+        Args:
+            planets: List of dicts with at least ``name`` and ``ecliptic_lon`` keys.
+
+        Returns:
+            List of dicts with keys ``planet_a``, ``planet_b``, ``aspect``, ``orb``.
+        """
+        results: List[Dict[str, Any]] = []
+        for i in range(len(planets)):
+            for j in range(i + 1, len(planets)):
+                pa = planets[i]
+                pb = planets[j]
+                diff = AstroDataProvider._angular_difference(
+                    pa["ecliptic_lon"], pb["ecliptic_lon"]
+                )
+                for angle, orb, name in _ASPECTS:
+                    separation = abs(diff - angle)
+                    if separation <= orb:
+                        results.append(
+                            {
+                                "planet_a": pa["name"],
+                                "planet_b": pb["name"],
+                                "aspect": name,
+                                "orb": round(separation, 2),
+                            }
+                        )
+                        break  # Each pair gets at most one aspect
+        return results
+
+    @staticmethod
+    def _assign_house(planet_zodiac: str, ascendant_sign: str) -> int:
+        """Return the whole-sign house number (1–12) for *planet_zodiac* given *ascendant_sign*.
+
+        Returns 0 for unknown sign names.
+        """
+        try:
+            asc_idx = _ZODIAC_SIGNS.index(ascendant_sign)
+            planet_idx = _ZODIAC_SIGNS.index(planet_zodiac)
+        except ValueError:
+            return 0
+        return (planet_idx - asc_idx) % 12 + 1
+
+    @staticmethod
+    def get_whole_sign_houses(ascendant_sign: str) -> Dict[int, Dict[str, str]]:
+        """Return a whole-sign house map for *ascendant_sign*.
+
+        Returns:
+            Dict mapping house number (1–12) → ``{"sign": str, "meaning": str}``.
+            Returns an empty dict for an unrecognised ascendant sign.
+        """
+        try:
+            asc_idx = _ZODIAC_SIGNS.index(ascendant_sign)
+        except ValueError:
+            return {}
+        houses: Dict[int, Dict[str, str]] = {}
+        for house_num in range(1, 13):
+            sign_idx = (asc_idx + house_num - 1) % 12
+            houses[house_num] = {
+                "sign": _ZODIAC_SIGNS[sign_idx],
+                "meaning": _HOUSE_MEANINGS[house_num],
+            }
+        return houses
+
+    @staticmethod
+    def _get_planet_dignity(planet_name: str, zodiac_sign: str) -> str:
+        """Return the traditional dignity of *planet_name* in *zodiac_sign*.
+
+        Returns one of: "Domicile", "Exaltation", "Detriment", "Fall", "Peregrine".
+        Domicile takes precedence over Exaltation when a sign qualifies for both
+        (e.g. Mercury in Virgo).
+        """
+        entry = _DIGNITY_TABLE.get(planet_name, {})
+        if zodiac_sign in entry.get("domicile", []):
+            return "Domicile"
+        if zodiac_sign in entry.get("exaltation", []):
+            return "Exaltation"
+        if zodiac_sign in entry.get("detriment", []):
+            return "Detriment"
+        if zodiac_sign in entry.get("fall", []):
+            return "Fall"
+        return "Peregrine"
+
+    @staticmethod
+    def _find_transit_hits(
+        transit_planets: List[Dict[str, Any]],
+        natal_planets: List[Dict[str, Any]],
+        orb: float = 3.0,
+    ) -> List[Dict[str, Any]]:
+        """Find transit planets within *orb* degrees of natal planets (conjunction only).
+
+        Returns:
+            List of dicts with keys: ``transit_planet``, ``natal_planet``, ``orb``.
+        """
+        hits: List[Dict[str, Any]] = []
+        for tp in transit_planets:
+            for np in natal_planets:
+                diff = AstroDataProvider._angular_difference(
+                    tp["ecliptic_lon"], np["ecliptic_lon"]
+                )
+                if diff <= orb:
+                    hits.append({
+                        "transit_planet": tp["name"],
+                        "natal_planet": np["name"],
+                        "orb": round(diff, 2),
+                    })
+        return hits
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_planet_longitudes(self, date: datetime) -> List[Dict[str, Any]]:
+        """Return tropical ecliptic longitudes for all 9 modern planets.
+
+        Uses the Moshier built-in ephemeris (``swe.FLG_MOSEPH``).
+
+        Returns:
+            List of dicts with keys: ``name``, ``ecliptic_lon``, ``zodiac``,
+            ``two_letter``.
+        """
+        jd = self._get_julian_day(date)
+        flags = swe.FLG_MOSEPH  # Moshier built-in — no data files needed
+        planets: List[Dict[str, Any]] = []
+        for name, planet_id in _PLANET_IDS.items():
+            result, _ = swe.calc_ut(jd, planet_id, flags)
+            lon_deg = float(result[0])
+            planets.append(
+                {
+                    "name": name,
+                    "ecliptic_lon": lon_deg,
+                    "zodiac": self._ecliptic_lon_to_zodiac(lon_deg),
+                    "two_letter": _PLANET_TWO_LETTER[name],
+                }
+            )
+        return planets
+
+    def get_natal_positions(self, birth_date: str, birth_time: str) -> List[Dict[str, Any]]:
+        """Compute tropical ecliptic positions for a birth chart.
+
+        Args:
+            birth_date: ISO date string ``YYYY-MM-DD``.
+            birth_time: 24-hour time string ``HH:MM``.
+
+        Returns:
+            List of 9 planet dicts matching the format of :meth:`get_planet_longitudes`.
+        """
+        year, month, day = (int(x) for x in birth_date.split("-"))
+        hour, minute = (int(x) for x in birth_time.split(":"))
+        birth_hour = hour + minute / 60.0
+        jd = swe.julday(year, month, day, birth_hour)
+        flags = swe.FLG_MOSEPH
+        planets: List[Dict[str, Any]] = []
+        for name, planet_id in _PLANET_IDS.items():
+            result, _ = swe.calc_ut(jd, planet_id, flags)
+            lon_deg = float(result[0])
+            planets.append({
+                "name": name,
+                "ecliptic_lon": lon_deg,
+                "zodiac": self._ecliptic_lon_to_zodiac(lon_deg),
+                "two_letter": _PLANET_TWO_LETTER[name],
+            })
+        return planets
+
+    def get_aspects(self, date: datetime) -> List[Dict[str, Any]]:
+        """Return all major astrological aspects for *date*."""
+        planets = self.get_planet_longitudes(date)
+        return self._compute_aspects(planets)
+
+    def get_moon_phase(self, date: datetime) -> str:
+        """Return the moon phase name for *date* at 22:00 UTC."""
+        jd = self._get_julian_day(date)
+        flags = swe.FLG_MOSEPH
+        sun_result, _ = swe.calc_ut(jd, swe.SUN, flags)
+        moon_result, _ = swe.calc_ut(jd, swe.MOON, flags)
+        sun_lon = float(sun_result[0])
+        moon_lon = float(moon_result[0])
+        elongation = (moon_lon - sun_lon) % 360.0
+        return self._moon_phase_name(elongation)
+
+    def get_horoscope_data(self, date: datetime) -> Dict[str, Any]:
+        """Return combined astrological data for LLM horoscope generation.
+
+        Returns:
+            Dict with keys:
+                ``planets``    — List[Dict] from :meth:`get_planet_longitudes`
+                ``aspects``    — List[Dict] from :meth:`get_aspects`
+                ``moon_phase`` — str from :meth:`get_moon_phase`
+        """
+        planets = self.get_planet_longitudes(date)
+        aspects = self._compute_aspects(planets)
+        moon_phase = self.get_moon_phase(date)
+        return {
+            "planets": planets,
+            "aspects": aspects,
+            "moon_phase": moon_phase,
+        }
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _moon_phase_name(elongation_deg: float) -> str:
+        """Return the phase name for a Sun–Moon elongation angle (0–360°)."""
+        e = elongation_deg % 360
+        if e < 22.5 or e >= 337.5:
+            return "New Moon"
+        elif e < 67.5:
+            return "Waxing Crescent"
+        elif e < 112.5:
+            return "First Quarter"
+        elif e < 157.5:
+            return "Waxing Gibbous"
+        elif e < 202.5:
+            return "Full Moon"
+        elif e < 247.5:
+            return "Waning Gibbous"
+        elif e < 292.5:
+            return "Last Quarter"
+        else:
+            return "Waning Crescent"

--- a/src/screamsheet/renderers/sky_highlights.py
+++ b/src/screamsheet/renderers/sky_highlights.py
@@ -12,7 +12,7 @@ from typing import Any, List, cast
 from reportlab.lib.colors import black
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.enums import TA_LEFT
-from reportlab.platypus import Paragraph, Spacer
+from reportlab.platypus import Paragraph
 
 from ..base import Section
 from ..llm.summarizers import SkyNightSummarizer
@@ -66,8 +66,6 @@ class SkyHighlightsSection(Section):
             self.fetch_data()
 
         elements: List[Any] = []
-        elements.append(Paragraph(self.title, self._heading_style))
-        elements.append(Spacer(1, 4))
 
         # Prefer LLM-generated bullets; fall back to raw highlights if unavailable.
         llm_output = self._get_llm_bullet()

--- a/src/screamsheet/renderers/sky_horoscope.py
+++ b/src/screamsheet/renderers/sky_horoscope.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
-from typing import Any, List
+from typing import Any, Dict, List, Optional
 
 from reportlab.lib.colors import HexColor
 from reportlab.lib.enums import TA_LEFT
@@ -19,19 +19,23 @@ from ..base import Section
 from ..config import PersonConfig
 from ..llm.config import DEFAULT_LLM_CONFIG
 from ..llm.summarizers import HoroscopeSummarizer
+from ..providers.astro_provider import AstroDataProvider
 
 
 class SkyHoroscopeSection(Section):
     """Renders two horoscope readings side-by-side for configured people.
 
     Args:
-        title:         Section heading.
-        provider:      SkyDataProvider instance.
-        date:          Target date (tonight).
-        location_name: Observer location (passed to the LLM prompt).
-        people:        List of up to 2 PersonConfig entries.  If empty,
-                       ``has_content()`` returns False and the section is
-                       omitted from the PDF.
+        title:          Section heading.
+        provider:       SkyDataProvider instance (Skyfield — used for Zodiac/highlights).
+        date:           Target date (tonight).
+        location_name:  Observer location (passed to the LLM prompt).
+        people:         List of up to 2 PersonConfig entries.  If empty,
+                        ``has_content()`` returns False and the section is
+                        omitted from the PDF.
+        astro_provider: Optional AstroDataProvider (Swiss Ephemeris).  When
+                        supplied, planet positions and aspects for the horoscope
+                        are sourced from Swiss Ephemeris instead of Skyfield.
     """
 
     def __init__(
@@ -41,12 +45,16 @@ class SkyHoroscopeSection(Section):
         date: datetime,
         location_name: str,
         people: List[PersonConfig],
+        astro_provider: Optional[AstroDataProvider] = None,
     ) -> None:
         super().__init__(title)
         self.provider = provider
         self.date = date
         self.location_name = location_name
         self.people = people
+        self.astro_provider = astro_provider
+        self.astro_data: Optional[dict] = None
+        self.natal_data: Dict[str, List[Dict[str, Any]]] = {}
 
         base = getSampleStyleSheet()
         self._heading_style = base["Heading2"]
@@ -74,8 +82,15 @@ class SkyHoroscopeSection(Section):
         return len(self.people) > 0
 
     def fetch_data(self) -> None:
-        sky = self.provider.get_sky_data(self.date)
-        self.data = sky
+        self.data = self.provider.get_sky_data(self.date)
+        self.natal_data = {}
+        if self.astro_provider is not None:
+            self.astro_data = self.astro_provider.get_horoscope_data(self.date)
+            for person in self.people:
+                if person.birth_date and person.birth_time:
+                    self.natal_data[person.name] = self.astro_provider.get_natal_positions(
+                        person.birth_date, person.birth_time
+                    )
 
     def render(self) -> List[Any]:
         if self.data is None:
@@ -124,8 +139,15 @@ class SkyHoroscopeSection(Section):
     # ------------------------------------------------------------------
 
     def _get_horoscope(self, person: PersonConfig) -> str:
-        """Return a ~200-word horoscope for *person*, or a fallback message."""
-        sky = self.data or {}
+        """Return a ~200-word horoscope for *person*, or a fallback message.
+
+        When ``astro_provider`` is set, planet positions and aspects are sourced
+        from Swiss Ephemeris (tropical zodiac, vernal-equinox anchored).  When
+        not set, falls back to Skyfield positions from the sky data dict.
+        """
+        sky: Dict[str, Any] = self.data or {}
+        astro = self.astro_data
+        natal_planets = self.natal_data.get(person.name, [])
 
         gemini_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
         grok_key = os.getenv("GROK_API_KEY") or os.getenv("XAI_API_KEY")
@@ -142,11 +164,66 @@ class SkyHoroscopeSection(Section):
                 grok_api_key=grok_key,
                 config=DEFAULT_LLM_CONFIG,
             )
-            planets_str = ", ".join(
-                f"{p['name']} in {p['zodiac']}"
-                for p in sky.get("planets", [])
-                if p.get("name") not in {"Uranus", "Neptune"}
+
+            # Transit planets: Swiss Ephemeris when available, else Skyfield fallback.
+            transit_source: List[Dict[str, Any]] = astro["planets"] if astro else sky.get("planets", [])
+            aspects_list: List[Dict[str, Any]] = astro["aspects"] if astro else []
+            moon_phase: str = astro["moon_phase"] if astro else sky.get("moon_phase", "")
+
+            # Enrich each transit planet with whole-sign house + dignity.
+            house_map = AstroDataProvider.get_whole_sign_houses(person.ascendant) if person.ascendant else {}
+            transit_enriched: List[Dict[str, Any]] = []
+            for p in transit_source:
+                house_num = AstroDataProvider._assign_house(p["zodiac"], person.ascendant) if person.ascendant else 0
+                house_info = house_map.get(house_num, {})
+                dignity = AstroDataProvider._get_planet_dignity(p["name"], p["zodiac"])
+                transit_enriched.append({
+                    **p,
+                    "house_number": house_num,
+                    "house_meaning": house_info.get("meaning", ""),
+                    "dignity": dignity,
+                })
+
+            # Hits: transit planets within 3° of natal planets.
+            hits = AstroDataProvider._find_transit_hits(transit_source, natal_planets) if natal_planets else []
+
+            # Build subject_natal block.
+            natal_planet_str = ", ".join(
+                f"{p['name']} in {p['zodiac']}" for p in natal_planets
             )
+            natal_line = f"Natal planets: {natal_planet_str}\n" if natal_planet_str else ""
+            subject_natal = (
+                f"Sun: {person.sun_sign} | Moon: {person.moon_sign} | Ascendant: {person.ascendant}\n"
+                f"{natal_line}"
+            ).strip()
+
+            # Build current_sky block.
+            planet_lines: List[str] = []
+            for p in transit_enriched:
+                if p.get("house_number"):
+                    planet_lines.append(
+                        f"- {p['name']} in {p['zodiac']} "
+                        f"(House {p['house_number']}: {p['house_meaning']}) [{p['dignity']}]"
+                    )
+                else:
+                    planet_lines.append(f"- {p['name']} in {p['zodiac']} [{p['dignity']}]")
+
+            aspects_str = ", ".join(
+                f"{a['planet_a']} {a['aspect']} {a['planet_b']}" for a in aspects_list
+            ) or "None"
+
+            hits_str = "\n".join(
+                f"- Transit {h['transit_planet']} conjunct natal {h['natal_planet']} (orb: {h['orb']}°)"
+                for h in hits
+            ) or "None"
+
+            current_sky = (
+                "Transit planets:\n" + "\n".join(planet_lines) + "\n\n"
+                f"Key aspects: {aspects_str}\n\n"
+                f"Hits (transit conjunct natal, orb ≤3°):\n{hits_str}\n\n"
+                f"Moon phase: {moon_phase}"
+            )
+
             llm_choice = "gemini" if gemini_key else "grok"
             result = summarizer.generate_summary(
                 llm_choice=llm_choice,
@@ -155,15 +232,13 @@ class SkyHoroscopeSection(Section):
                     "birth_date": person.birth_date,
                     "birth_time": person.birth_time,
                     "birth_location": person.birth_location,
-                    "sun_sign": person.sun_sign,
-                    "moon_sign": person.moon_sign,
-                    "ascendant": person.ascendant,
-                    "planets": planets_str,
-                    "moon_phase": sky.get("moon_phase", ""),
                     "date": self.date.strftime("%B %d, %Y"),
                     "location": self.location_name,
+                    "subject_natal": subject_natal,
+                    "current_sky": current_sky,
                 },
             )
             return str(result).strip() if result else f"Horoscope unavailable for {person.name}."
         except Exception:  # noqa: BLE001
             return f"Horoscope unavailable for {person.name}."
+

--- a/src/screamsheet/sky/sky_tonight.py
+++ b/src/screamsheet/sky/sky_tonight.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 
 from ..base import BaseScreamsheet, Section
 from ..config import PersonConfig
+from ..providers.astro_provider import AstroDataProvider
 from ..providers.sky_provider import SkyDataProvider
 from ..renderers.zodiac_wheel import ZodiacWheelSection
 from ..renderers.sky_highlights import SkyHighlightsSection
@@ -44,6 +45,7 @@ class SkyTonightScreamsheet(BaseScreamsheet):
         self.location_name = location_name
         self.people: List[PersonConfig] = people if people is not None else []
         self.provider = SkyDataProvider(lat=lat, lon=lon, location_name=location_name)
+        self.astro_provider = AstroDataProvider()
 
     # ------------------------------------------------------------------
     # BaseScreamsheet interface
@@ -74,5 +76,6 @@ class SkyTonightScreamsheet(BaseScreamsheet):
                 date=self.date,
                 location_name=self.location_name,
                 people=self.people,
+                astro_provider=self.astro_provider,
             ),
         ]

--- a/tests/test_astro_provider.py
+++ b/tests/test_astro_provider.py
@@ -1,0 +1,388 @@
+"""Tests for AstroDataProvider (Swiss Ephemeris / pyswisseph).
+
+Each test verifies exactly one behaviour (SRP).
+All planet-position and aspect computations use the Moshier built-in ephemeris
+(swe.FLG_MOSEPH), so no external data files are required.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from screamsheet.providers.astro_provider import AstroDataProvider
+
+_DATE = datetime(2026, 4, 23)
+_PROVIDER = AstroDataProvider()
+
+
+# ---------------------------------------------------------------------------
+# Initialisation
+# ---------------------------------------------------------------------------
+
+class TestAstroDataProviderInit:
+    def test_instantiates_without_arguments(self) -> None:
+        provider = AstroDataProvider()
+        assert provider is not None
+
+
+# ---------------------------------------------------------------------------
+# DataProvider stub overrides
+# ---------------------------------------------------------------------------
+
+class TestDataProviderStubs:
+    def test_get_game_scores_returns_empty_list(self) -> None:
+        assert _PROVIDER.get_game_scores(_DATE) == []
+
+    def test_get_standings_returns_empty_list(self) -> None:
+        assert _PROVIDER.get_standings() == []
+
+
+# ---------------------------------------------------------------------------
+# _ecliptic_lon_to_zodiac  (pure static helper — same mapping as SkyProvider)
+# ---------------------------------------------------------------------------
+
+class TestEclipticLonToZodiac:
+    def test_zero_degrees_is_aries(self) -> None:
+        assert AstroDataProvider._ecliptic_lon_to_zodiac(0.0) == "Aries"
+
+    def test_29_degrees_is_aries(self) -> None:
+        assert AstroDataProvider._ecliptic_lon_to_zodiac(29.9) == "Aries"
+
+    def test_30_degrees_is_taurus(self) -> None:
+        assert AstroDataProvider._ecliptic_lon_to_zodiac(30.0) == "Taurus"
+
+    def test_180_degrees_is_libra(self) -> None:
+        assert AstroDataProvider._ecliptic_lon_to_zodiac(180.0) == "Libra"
+
+    def test_330_degrees_is_pisces(self) -> None:
+        assert AstroDataProvider._ecliptic_lon_to_zodiac(330.0) == "Pisces"
+
+    def test_360_wraps_to_aries(self) -> None:
+        assert AstroDataProvider._ecliptic_lon_to_zodiac(360.0) == "Aries"
+
+
+# ---------------------------------------------------------------------------
+# get_planet_longitudes
+# ---------------------------------------------------------------------------
+
+class TestGetPlanetLongitudes:
+    def test_returns_nine_planets(self) -> None:
+        planets = _PROVIDER.get_planet_longitudes(_DATE)
+        assert len(planets) == 9
+
+    def test_each_planet_has_name_key(self) -> None:
+        planets = _PROVIDER.get_planet_longitudes(_DATE)
+        for p in planets:
+            assert "name" in p
+
+    def test_each_planet_has_float_longitude(self) -> None:
+        planets = _PROVIDER.get_planet_longitudes(_DATE)
+        for p in planets:
+            assert isinstance(p["ecliptic_lon"], float)
+
+    def test_each_planet_has_zodiac_sign(self) -> None:
+        planets = _PROVIDER.get_planet_longitudes(_DATE)
+        valid_signs = {
+            "Aries", "Taurus", "Gemini", "Cancer", "Leo", "Virgo",
+            "Libra", "Scorpio", "Sagittarius", "Capricorn", "Aquarius", "Pisces",
+        }
+        for p in planets:
+            assert p["zodiac"] in valid_signs
+
+    def test_longitudes_in_range_0_to_360(self) -> None:
+        planets = _PROVIDER.get_planet_longitudes(_DATE)
+        for p in planets:
+            assert 0.0 <= p["ecliptic_lon"] < 360.0
+
+    def test_includes_sun(self) -> None:
+        planets = _PROVIDER.get_planet_longitudes(_DATE)
+        names = [p["name"] for p in planets]
+        assert "Sun" in names
+
+    def test_includes_neptune(self) -> None:
+        planets = _PROVIDER.get_planet_longitudes(_DATE)
+        names = [p["name"] for p in planets]
+        assert "Neptune" in names
+
+
+# ---------------------------------------------------------------------------
+# _compute_aspects  (pure helper — use controlled longitude inputs)
+# ---------------------------------------------------------------------------
+
+class TestComputeAspects:
+    def _lons(self, pairs: dict[str, float]) -> list[dict]:
+        """Build a minimal planet list from name→longitude mapping."""
+        return [{"name": name, "ecliptic_lon": lon} for name, lon in pairs.items()]
+
+    def test_conjunction_detected_within_orb(self) -> None:
+        lons = self._lons({"Sun": 0.0, "Moon": 3.0})
+        aspects = AstroDataProvider._compute_aspects(lons)
+        assert any(a["aspect"] == "Conjunction" for a in aspects)
+
+    def test_conjunction_not_detected_outside_orb(self) -> None:
+        lons = self._lons({"Sun": 0.0, "Moon": 10.0})
+        aspects = AstroDataProvider._compute_aspects(lons)
+        assert not any(a["aspect"] == "Conjunction" for a in aspects)
+
+    def test_opposition_detected_within_orb(self) -> None:
+        lons = self._lons({"Sun": 0.0, "Moon": 177.0})
+        aspects = AstroDataProvider._compute_aspects(lons)
+        assert any(a["aspect"] == "Opposition" for a in aspects)
+
+    def test_square_detected_within_orb(self) -> None:
+        lons = self._lons({"Sun": 0.0, "Moon": 93.0})
+        aspects = AstroDataProvider._compute_aspects(lons)
+        assert any(a["aspect"] == "Square" for a in aspects)
+
+    def test_trine_detected_within_orb(self) -> None:
+        lons = self._lons({"Sun": 0.0, "Moon": 122.0})
+        aspects = AstroDataProvider._compute_aspects(lons)
+        assert any(a["aspect"] == "Trine" for a in aspects)
+
+    def test_sextile_detected_within_orb(self) -> None:
+        lons = self._lons({"Sun": 0.0, "Moon": 63.0})
+        aspects = AstroDataProvider._compute_aspects(lons)
+        assert any(a["aspect"] == "Sextile" for a in aspects)
+
+    def test_sextile_not_detected_outside_orb(self) -> None:
+        lons = self._lons({"Sun": 0.0, "Moon": 68.0})
+        aspects = AstroDataProvider._compute_aspects(lons)
+        assert not any(a["aspect"] == "Sextile" for a in aspects)
+
+    def test_aspect_dict_has_required_keys(self) -> None:
+        lons = self._lons({"Sun": 0.0, "Moon": 0.5})
+        aspects = AstroDataProvider._compute_aspects(lons)
+        assert len(aspects) >= 1
+        a = aspects[0]
+        assert "planet_a" in a
+        assert "planet_b" in a
+        assert "aspect" in a
+        assert "orb" in a
+
+    def test_no_aspects_for_unrelated_pair(self) -> None:
+        # 45° is not a major aspect angle
+        lons = self._lons({"Sun": 0.0, "Moon": 45.0})
+        aspects = AstroDataProvider._compute_aspects(lons)
+        assert len(aspects) == 0
+
+    def test_angle_wraps_correctly_across_360(self) -> None:
+        # 350° and 5° are 15° apart — no conjunction (>8°)
+        lons = self._lons({"Sun": 350.0, "Moon": 5.0})
+        aspects = AstroDataProvider._compute_aspects(lons)
+        assert not any(a["aspect"] == "Conjunction" for a in aspects)
+
+    def test_angle_wraps_correctly_within_orb(self) -> None:
+        # 355° and 2° are 7° apart — conjunction within ±8°
+        lons = self._lons({"Sun": 355.0, "Moon": 2.0})
+        aspects = AstroDataProvider._compute_aspects(lons)
+        assert any(a["aspect"] == "Conjunction" for a in aspects)
+
+
+# ---------------------------------------------------------------------------
+# get_moon_phase
+# ---------------------------------------------------------------------------
+
+class TestGetMoonPhase:
+    def test_returns_non_empty_string(self) -> None:
+        result = _PROVIDER.get_moon_phase(_DATE)
+        assert isinstance(result, str) and len(result) > 0
+
+    def test_returns_known_phase_name(self) -> None:
+        known_phases = {
+            "New Moon", "Waxing Crescent", "First Quarter", "Waxing Gibbous",
+            "Full Moon", "Waning Gibbous", "Last Quarter", "Waning Crescent",
+        }
+        result = _PROVIDER.get_moon_phase(_DATE)
+        assert result in known_phases
+
+
+# ---------------------------------------------------------------------------
+# get_horoscope_data
+# ---------------------------------------------------------------------------
+
+class TestGetHoroscopeData:
+    def test_returns_dict(self) -> None:
+        result = _PROVIDER.get_horoscope_data(_DATE)
+        assert isinstance(result, dict)
+
+    def test_has_planets_key(self) -> None:
+        result = _PROVIDER.get_horoscope_data(_DATE)
+        assert "planets" in result
+
+    def test_has_aspects_key(self) -> None:
+        result = _PROVIDER.get_horoscope_data(_DATE)
+        assert "aspects" in result
+
+    def test_has_moon_phase_key(self) -> None:
+        result = _PROVIDER.get_horoscope_data(_DATE)
+        assert "moon_phase" in result
+
+    def test_planets_is_list(self) -> None:
+        result = _PROVIDER.get_horoscope_data(_DATE)
+        assert isinstance(result["planets"], list)
+
+    def test_aspects_is_list(self) -> None:
+        result = _PROVIDER.get_horoscope_data(_DATE)
+        assert isinstance(result["aspects"], list)
+
+
+# ---------------------------------------------------------------------------
+# get_natal_positions
+# ---------------------------------------------------------------------------
+
+class TestGetNatalPositions:
+    def test_returns_nine_planets(self) -> None:
+        planets = _PROVIDER.get_natal_positions("1978-02-26", "01:20")
+        assert len(planets) == 9
+
+    def test_each_planet_has_float_longitude(self) -> None:
+        planets = _PROVIDER.get_natal_positions("1978-02-26", "01:20")
+        for p in planets:
+            assert isinstance(p["ecliptic_lon"], float)
+
+    def test_longitudes_in_range_0_to_360(self) -> None:
+        planets = _PROVIDER.get_natal_positions("1978-02-26", "01:20")
+        for p in planets:
+            assert 0.0 <= p["ecliptic_lon"] < 360.0
+
+    def test_accepts_string_birth_date_and_time(self) -> None:
+        planets = _PROVIDER.get_natal_positions("2000-01-01", "12:00")
+        assert len(planets) > 0
+
+    def test_sun_position_differs_from_transit(self) -> None:
+        natal = _PROVIDER.get_natal_positions("1978-02-26", "01:20")
+        transit = _PROVIDER.get_planet_longitudes(_DATE)
+        natal_sun = next(p["ecliptic_lon"] for p in natal if p["name"] == "Sun")
+        transit_sun = next(p["ecliptic_lon"] for p in transit if p["name"] == "Sun")
+        assert natal_sun != transit_sun
+
+
+# ---------------------------------------------------------------------------
+# _assign_house  (pure static helper)
+# ---------------------------------------------------------------------------
+
+class TestAssignHouse:
+    def test_asc_sign_is_house_1(self) -> None:
+        assert AstroDataProvider._assign_house("Scorpio", "Scorpio") == 1
+
+    def test_next_sign_is_house_2(self) -> None:
+        assert AstroDataProvider._assign_house("Sagittarius", "Scorpio") == 2
+
+    def test_taurus_is_house_7_for_scorpio_asc(self) -> None:
+        assert AstroDataProvider._assign_house("Taurus", "Scorpio") == 7
+
+    def test_wraps_correctly_at_house_12(self) -> None:
+        assert AstroDataProvider._assign_house("Libra", "Scorpio") == 12
+
+    def test_unknown_sign_returns_zero(self) -> None:
+        assert AstroDataProvider._assign_house("NotASign", "Scorpio") == 0
+
+
+# ---------------------------------------------------------------------------
+# get_whole_sign_houses  (pure static helper)
+# ---------------------------------------------------------------------------
+
+class TestGetWholeSignHouses:
+    def test_returns_12_entries(self) -> None:
+        houses = AstroDataProvider.get_whole_sign_houses("Scorpio")
+        assert len(houses) == 12
+
+    def test_house_1_is_ascendant_sign(self) -> None:
+        houses = AstroDataProvider.get_whole_sign_houses("Scorpio")
+        assert houses[1]["sign"] == "Scorpio"
+
+    def test_house_2_is_next_sign(self) -> None:
+        houses = AstroDataProvider.get_whole_sign_houses("Scorpio")
+        assert houses[2]["sign"] == "Sagittarius"
+
+    def test_house_7_is_opposite_sign_for_scorpio(self) -> None:
+        houses = AstroDataProvider.get_whole_sign_houses("Scorpio")
+        assert houses[7]["sign"] == "Taurus"
+
+    def test_each_entry_has_meaning(self) -> None:
+        houses = AstroDataProvider.get_whole_sign_houses("Scorpio")
+        for num, info in houses.items():
+            assert "meaning" in info
+            assert len(info["meaning"]) > 0
+
+    def test_unknown_ascendant_returns_empty(self) -> None:
+        houses = AstroDataProvider.get_whole_sign_houses("NotASign")
+        assert houses == {}
+
+
+# ---------------------------------------------------------------------------
+# _get_planet_dignity  (pure static helper)
+# ---------------------------------------------------------------------------
+
+class TestGetPlanetDignity:
+    def test_sun_in_leo_is_domicile(self) -> None:
+        assert AstroDataProvider._get_planet_dignity("Sun", "Leo") == "Domicile"
+
+    def test_sun_in_aries_is_exaltation(self) -> None:
+        assert AstroDataProvider._get_planet_dignity("Sun", "Aries") == "Exaltation"
+
+    def test_sun_in_aquarius_is_detriment(self) -> None:
+        assert AstroDataProvider._get_planet_dignity("Sun", "Aquarius") == "Detriment"
+
+    def test_sun_in_libra_is_fall(self) -> None:
+        assert AstroDataProvider._get_planet_dignity("Sun", "Libra") == "Fall"
+
+    def test_sun_in_taurus_is_peregrine(self) -> None:
+        assert AstroDataProvider._get_planet_dignity("Sun", "Taurus") == "Peregrine"
+
+    def test_mars_in_aries_is_domicile(self) -> None:
+        assert AstroDataProvider._get_planet_dignity("Mars", "Aries") == "Domicile"
+
+    def test_saturn_in_aries_is_fall(self) -> None:
+        assert AstroDataProvider._get_planet_dignity("Saturn", "Aries") == "Fall"
+
+    def test_unknown_planet_returns_peregrine(self) -> None:
+        assert AstroDataProvider._get_planet_dignity("Pluto", "Scorpio") == "Peregrine"
+
+
+# ---------------------------------------------------------------------------
+# _find_transit_hits  (pure static helper)
+# ---------------------------------------------------------------------------
+
+class TestFindTransitHits:
+    def _planets(self, pairs: dict[str, float]) -> list[dict]:
+        return [{"name": n, "ecliptic_lon": lon} for n, lon in pairs.items()]
+
+    def test_returns_hit_within_orb(self) -> None:
+        transit = self._planets({"Mars": 30.0})
+        natal = self._planets({"Sun": 31.5})
+        hits = AstroDataProvider._find_transit_hits(transit, natal, orb=3.0)
+        assert len(hits) == 1
+
+    def test_returns_empty_outside_orb(self) -> None:
+        transit = self._planets({"Mars": 30.0})
+        natal = self._planets({"Sun": 35.0})
+        hits = AstroDataProvider._find_transit_hits(transit, natal, orb=3.0)
+        assert len(hits) == 0
+
+    def test_hit_dict_has_required_keys(self) -> None:
+        transit = self._planets({"Mars": 30.0})
+        natal = self._planets({"Sun": 30.5})
+        hits = AstroDataProvider._find_transit_hits(transit, natal, orb=3.0)
+        assert "transit_planet" in hits[0]
+        assert "natal_planet" in hits[0]
+        assert "orb" in hits[0]
+
+    def test_correct_planet_names_in_hit(self) -> None:
+        transit = self._planets({"Mars": 30.0})
+        natal = self._planets({"Sun": 30.5})
+        hits = AstroDataProvider._find_transit_hits(transit, natal, orb=3.0)
+        assert hits[0]["transit_planet"] == "Mars"
+        assert hits[0]["natal_planet"] == "Sun"
+
+    def test_wraps_across_360_degrees(self) -> None:
+        transit = self._planets({"Mars": 1.0})
+        natal = self._planets({"Sun": 359.0})
+        hits = AstroDataProvider._find_transit_hits(transit, natal, orb=3.0)
+        assert len(hits) == 1
+
+    def test_returns_empty_list_for_no_planets(self) -> None:
+        hits = AstroDataProvider._find_transit_hits([], [], orb=3.0)
+        assert hits == []

--- a/tests/test_sky_horoscope.py
+++ b/tests/test_sky_horoscope.py
@@ -1,7 +1,7 @@
 """Tests for SkyHoroscopeSection renderer."""
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from datetime import datetime
 
 from screamsheet.config import PersonConfig
@@ -78,3 +78,178 @@ def test_render_returns_list_with_no_api_keys(monkeypatch) -> None:
     result = section.render()
     assert isinstance(result, list)
     assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# AstroDataProvider injection
+# ---------------------------------------------------------------------------
+
+def _make_astro_provider() -> MagicMock:
+    astro = MagicMock()
+    astro.get_horoscope_data.return_value = {
+        "planets": [
+            {"name": "Sun", "zodiac": "Taurus", "ecliptic_lon": 31.0, "two_letter": "Su"},
+            {"name": "Moon", "zodiac": "Cancer", "ecliptic_lon": 92.0, "two_letter": "Mo"},
+        ],
+        "aspects": [
+            {"planet_a": "Sun", "planet_b": "Moon", "aspect": "Square", "orb": 1.0},
+        ],
+        "moon_phase": "Waxing Crescent",
+    }
+    # Transit Moon at 92.0° hits natal Moon at 92.5° (orb 0.5° < 3°)
+    astro.get_natal_positions.return_value = [
+        {"name": "Sun",  "zodiac": "Virgo",  "ecliptic_lon": 157.0, "two_letter": "Su"},
+        {"name": "Moon", "zodiac": "Cancer", "ecliptic_lon": 92.5,  "two_letter": "Mo"},
+    ]
+    return astro
+
+
+def test_astro_provider_is_called_during_fetch(monkeypatch) -> None:
+    """AstroDataProvider.get_horoscope_data must be called when injected."""
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GROK_API_KEY", raising=False)
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+
+    astro = _make_astro_provider()
+    section = SkyHoroscopeSection(
+        title="Horoscopes",
+        provider=_make_provider(),
+        date=datetime(2026, 4, 21),
+        location_name="Bryn Mawr, PA",
+        people=_make_people(),
+        astro_provider=astro,
+    )
+    section.fetch_data()
+    astro.get_horoscope_data.assert_called_once_with(datetime(2026, 4, 21))
+
+
+def test_astro_provider_none_does_not_raise(monkeypatch) -> None:
+    """Section must work correctly when astro_provider is not injected."""
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GROK_API_KEY", raising=False)
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+
+    section = SkyHoroscopeSection(
+        title="Horoscopes",
+        provider=_make_provider(),
+        date=datetime(2026, 4, 21),
+        location_name="Bryn Mawr, PA",
+        people=_make_people(),
+        astro_provider=None,
+    )
+    result = section.render()
+    assert isinstance(result, list)
+    assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# LLM data structure: subject_natal / current_sky separation
+# ---------------------------------------------------------------------------
+
+def _make_person_with_natal() -> PersonConfig:
+    return PersonConfig(
+        name="Alice",
+        birth_date="1978-02-26",
+        birth_time="01:20",
+        birth_location="Wauwatosa, WI",
+        sun_sign="Virgo",
+        moon_sign="Cancer",
+        ascendant="Scorpio",
+    )
+
+
+def _call_get_horoscope_with_mock_summarizer(
+    monkeypatch, astro_provider: MagicMock
+) -> dict:
+    """Helper: run _get_horoscope with a mocked summarizer; return the data kwarg."""
+    monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
+    with patch("screamsheet.renderers.sky_horoscope.HoroscopeSummarizer") as MockSummarizer:
+        mock_instance = MockSummarizer.return_value
+        mock_instance.generate_summary.return_value = "A reading."
+        section = SkyHoroscopeSection(
+            title="Horoscopes",
+            provider=_make_provider(),
+            date=datetime(2026, 4, 21),
+            location_name="Bryn Mawr, PA",
+            people=[_make_person_with_natal()],
+            astro_provider=astro_provider,
+        )
+        section.fetch_data()
+        section._get_horoscope(_make_person_with_natal())
+        return mock_instance.generate_summary.call_args.kwargs["data"]
+
+
+def test_llm_data_has_subject_natal_key(monkeypatch) -> None:
+    """generate_summary data must include a 'subject_natal' key."""
+    data = _call_get_horoscope_with_mock_summarizer(monkeypatch, _make_astro_provider())
+    assert "subject_natal" in data
+
+
+def test_llm_data_has_current_sky_key(monkeypatch) -> None:
+    """generate_summary data must include a 'current_sky' key."""
+    data = _call_get_horoscope_with_mock_summarizer(monkeypatch, _make_astro_provider())
+    assert "current_sky" in data
+
+
+def test_llm_data_subject_natal_contains_sun_sign(monkeypatch) -> None:
+    """subject_natal string must contain the person's natal Sun sign."""
+    data = _call_get_horoscope_with_mock_summarizer(monkeypatch, _make_astro_provider())
+    assert "Virgo" in data["subject_natal"]
+
+
+def test_llm_data_current_sky_contains_transit_planets(monkeypatch) -> None:
+    """current_sky string must contain transit planet text."""
+    data = _call_get_horoscope_with_mock_summarizer(monkeypatch, _make_astro_provider())
+    assert "Transit planets" in data["current_sky"]
+
+
+def test_llm_data_current_sky_contains_aspects(monkeypatch) -> None:
+    """current_sky string must contain aspect text."""
+    data = _call_get_horoscope_with_mock_summarizer(monkeypatch, _make_astro_provider())
+    assert "Key aspects" in data["current_sky"]
+
+
+def test_llm_data_does_not_have_flat_sun_sign_key(monkeypatch) -> None:
+    """Flat 'sun_sign' key must not appear in data — it lives inside subject_natal."""
+    data = _call_get_horoscope_with_mock_summarizer(monkeypatch, _make_astro_provider())
+    assert "sun_sign" not in data
+
+
+def test_llm_data_does_not_have_flat_planets_key(monkeypatch) -> None:
+    """Flat 'planets' key must not appear in data — it lives inside current_sky."""
+    data = _call_get_horoscope_with_mock_summarizer(monkeypatch, _make_astro_provider())
+    assert "planets" not in data
+
+
+# ---------------------------------------------------------------------------
+# Enriched current_sky: house placement, dignity, hits
+# ---------------------------------------------------------------------------
+
+def test_llm_data_current_sky_contains_house_number(monkeypatch) -> None:
+    """current_sky must reference a house number."""
+    # Sun in Taurus, Scorpio ASC → House 7
+    data = _call_get_horoscope_with_mock_summarizer(monkeypatch, _make_astro_provider())
+    assert "House 7" in data["current_sky"]
+
+
+def test_llm_data_current_sky_contains_house_meaning(monkeypatch) -> None:
+    """current_sky must include the house meaning text."""
+    # House 7 meaning includes 'Partnerships'
+    data = _call_get_horoscope_with_mock_summarizer(monkeypatch, _make_astro_provider())
+    assert "Partnerships" in data["current_sky"]
+
+
+def test_llm_data_current_sky_contains_dignity(monkeypatch) -> None:
+    """current_sky must label each transit planet's dignity."""
+    # Sun in Taurus is Peregrine (not Leo/Aries/Aquarius/Libra)
+    data = _call_get_horoscope_with_mock_summarizer(monkeypatch, _make_astro_provider())
+    assert "Peregrine" in data["current_sky"]
+
+
+def test_llm_data_current_sky_contains_hits(monkeypatch) -> None:
+    """current_sky must list conjunctions of transit and natal planets."""
+    # Transit Moon at 92.0° conjuncts natal Moon at 92.5° (orb 0.5°)
+    data = _call_get_horoscope_with_mock_summarizer(monkeypatch, _make_astro_provider())
+    assert "conjunct natal Moon" in data["current_sky"]

--- a/uv.lock
+++ b/uv.lock
@@ -730,6 +730,27 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/6b/3d5c13fb3e3c4f43206c8f9dfed13778c2ed4f000bacaa0b7ce3c402a265/librt-0.9.0.tar.gz", hash = "sha256:a0951822531e7aee6e0dfb556b30d5ee36bbe234faf60c20a16c01be3530869d", size = 184368, upload-time = "2026-04-09T16:06:26.173Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/90/89ddba8e1c20b0922783cd93ed8e64f34dc05ab59c38a9c7e313632e20ff/librt-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b3e3bc363f71bda1639a4ee593cb78f7fbfeacc73411ec0d4c92f00730010a4", size = 68332, upload-time = "2026-04-09T16:05:00.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/7aa4da1fb08bdeeb540cb07bfc8207cb32c5c41642f2594dbd0098a0662d/librt-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a09c2f5869649101738653a9b7ab70cf045a1105ac66cbb8f4055e61df78f2d", size = 70581, upload-time = "2026-04-09T16:05:01.213Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/73a2187e1031041e93b7e3a25aae37aa6f13b838c550f7e0f06f66766212/librt-0.9.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5ca8e133d799c948db2ab1afc081c333a825b5540475164726dcbf73537e5c2f", size = 203984, upload-time = "2026-04-09T16:05:02.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/3d/23460d571e9cbddb405b017681df04c142fb1b04cbfce77c54b08e28b108/librt-0.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:603138ee838ee1583f1b960b62d5d0007845c5c423feb68e44648b1359014e27", size = 215762, upload-time = "2026-04-09T16:05:04.127Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1e/42dc7f8ab63e65b20640d058e63e97fd3e482c1edbda3570d813b4d0b927/librt-0.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4003f70c56a5addd6aa0897f200dd59afd3bf7bcd5b3cce46dd21f925743bc2", size = 230288, upload-time = "2026-04-09T16:05:05.883Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/08/ca812b6d8259ad9ece703397f8ad5c03af5b5fedfce64279693d3ce4087c/librt-0.9.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78042f6facfd98ecb25e9829c7e37cce23363d9d7c83bc5f72702c5059eb082b", size = 224103, upload-time = "2026-04-09T16:05:07.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3f/620490fb2fa66ffd44e7f900254bc110ebec8dac6c1b7514d64662570e6f/librt-0.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a361c9434a64d70a7dbb771d1de302c0cc9f13c0bffe1cf7e642152814b35265", size = 232122, upload-time = "2026-04-09T16:05:08.386Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/83/12864700a1b6a8be458cf5d05db209b0d8e94ae281e7ec261dbe616597b4/librt-0.9.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:dd2c7e082b0b92e1baa4da28163a808672485617bc855cc22a2fd06978fa9084", size = 225045, upload-time = "2026-04-09T16:05:09.707Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1b/845d339c29dc7dbc87a2e992a1ba8d28d25d0e0372f9a0a2ecebde298186/librt-0.9.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7e6274fd33fc5b2a14d41c9119629d3ff395849d8bcbc80cf637d9e8d2034da8", size = 227372, upload-time = "2026-04-09T16:05:10.942Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fe/277985610269d926a64c606f761d58d3db67b956dbbf40024921e95e7fcb/librt-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5093043afb226ecfa1400120d1ebd4442b4f99977783e4f4f7248879009b227f", size = 248224, upload-time = "2026-04-09T16:05:12.254Z" },
+    { url = "https://files.pythonhosted.org/packages/92/1b/ee486d244b8de6b8b5dbaefabe6bfdd4a72e08f6353edf7d16d27114da8d/librt-0.9.0-cp312-cp312-win32.whl", hash = "sha256:9edcc35d1cae9fd5320171b1a838c7da8a5c968af31e82ecc3dff30b4be0957f", size = 55986, upload-time = "2026-04-09T16:05:13.529Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7a/ba1737012308c17dc6d5516143b5dce9a2c7ba3474afd54e11f44a4d1ef3/librt-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc2917258e131ae5f958a4d872e07555b51cb7466a43433218061c74ef33745", size = 63260, upload-time = "2026-04-09T16:05:14.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e4/01752c113da15127f18f7bf11142f5640038f062407a611c059d0036c6aa/librt-0.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:90e6d5420fc8a300518d4d2288154ff45005e920425c22cbbfe8330f3f754bd9", size = 53694, upload-time = "2026-04-09T16:05:16.095Z" },
+]
+
+[[package]]
 name = "lorem-text"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -775,6 +796,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/46/e2/348cd32faad84eaf1d20cce80e2bb0ef8d312c55bca1f7fa9865e7770aaf/multidict-6.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:92abb658ef2d7ef22ac9f8bb88e8b6c3e571671534e029359b6d9e845923eb1b", size = 46073, upload-time = "2025-10-06T14:49:50.28Z" },
     { url = "https://files.pythonhosted.org/packages/25/ec/aad2613c1910dce907480e0c3aa306905830f25df2e54ccc9dea450cb5aa/multidict-6.7.0-cp312-cp312-win_arm64.whl", hash = "sha256:490dab541a6a642ce1a9d61a4781656b346a55c13038f0b1244653828e3a83ec", size = 43226, upload-time = "2025-10-06T14:49:52.304Z" },
     { url = "https://files.pythonhosted.org/packages/b7/da/7d22601b625e241d4f23ef1ebff8acfc60da633c9e7e7922e24d10f592b3/multidict-6.7.0-py3-none-any.whl", hash = "sha256:394fc5c42a333c9ffc3e421a4c85e08580d990e08b99f6bf35b4132114c5dcb3", size = 12317, upload-time = "2025-10-06T14:52:29.272Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.20.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/4e/7560e4528db9e9b147e4c0f22660466bf30a0a1fe3d63d1b9d3b0fd354ee/mypy-1.20.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4dbfcf869f6b0517f70cf0030ba6ea1d6645e132337a7d5204a18d8d5636c02b", size = 14539393, upload-time = "2026-04-21T17:07:12.52Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d9/34a5efed8124f5a9234f55ac6a4ced4201e2c5b81e1109c49ad23190ec8c/mypy-1.20.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b6481b228d072315b053210b01ac320e1be243dc17f9e5887ef167f23f5fae4", size = 13361642, upload-time = "2026-04-21T17:06:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/14/eb377acf78c03c92d566a1510cda8137348215b5335085ef662ab82ecd3a/mypy-1.20.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34397cdced6b90b836e38182076049fdb41424322e0b0728c946b0939ebdf9f6", size = 13740347, upload-time = "2026-04-21T17:12:04.73Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/94/7e4634a32b641aa1c112422eed1bbece61ee16205f674190e8b536f884de/mypy-1.20.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5da6976f20cae27059ea8d0c86e7cef3de720e04c4bb9ee18e3690fdb792066", size = 14734042, upload-time = "2026-04-21T17:07:43.16Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f3/f7e62395cb7f434541b4491a01149a4439e28ace4c0c632bbf5431e92d1f/mypy-1.20.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56908d7e08318d39f85b1f0c6cfd47b0cac1a130da677630dac0de3e0623e102", size = 14964958, upload-time = "2026-04-21T17:11:00.665Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0d/47e3c3a0ec2a876e35aeac365df3cac7776c36bbd4ed18cc521e1b9d255b/mypy-1.20.2-cp312-cp312-win_amd64.whl", hash = "sha256:d52ad8d78522da1d308789df651ee5379088e77c76cb1994858d40a426b343b9", size = 10911340, upload-time = "2026-04-21T17:10:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/b2/6c852d72e0ea8b01f49da817fb52539993cde327e7d010e0103dc12d0dac/mypy-1.20.2-cp312-cp312-win_arm64.whl", hash = "sha256:785b08db19c9f214dc37d65f7c165d19a30fcecb48abfa30f31b01b5acaabb58", size = 9833947, upload-time = "2026-04-21T17:09:05.267Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/f23c163e25b11074188251b0b5a0342625fc1cdb6af604757174fa9acc9b/mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563", size = 2637314, upload-time = "2026-04-21T17:05:54.5Z" },
 ]
 
 [[package]]
@@ -917,6 +960,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/14/cec7760d7c9507f11c97d64f29022e12a6cc4fc03ac694535e89f88ad2ec/pandas-2.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:56a342b231e8862c96bdb6ab97170e203ce511f4d0429589c8ede1ee8ece48b8", size = 12767210, upload-time = "2025-07-07T19:19:02.944Z" },
     { url = "https://files.pythonhosted.org/packages/50/b9/6e2d2c6728ed29fb3d4d4d302504fb66f1a543e37eb2e43f352a86365cdf/pandas-2.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ca7ed14832bce68baef331f4d7f294411bed8efd032f8109d690df45e00c4679", size = 13440571, upload-time = "2025-07-07T19:19:06.82Z" },
     { url = "https://files.pythonhosted.org/packages/80/a5/3a92893e7399a691bad7664d977cb5e7c81cf666c81f89ea76ba2bff483d/pandas-2.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ac942bfd0aca577bef61f2bc8da8147c4ef6879965ef883d8e8d5d2dc3e744b8", size = 10987601, upload-time = "2025-07-07T19:19:09.589Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/17/9c3094b822982b9f1ea666d8580ce59000f61f87c1663556fb72031ad9ec/pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080", size = 133918, upload-time = "2026-04-23T01:46:22.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/c9/8eed0486f074e9f1ca7f8ce5ad663e65f12fdab344028d658fa1b03d35e0/pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42", size = 56264, upload-time = "2026-04-23T01:46:20.606Z" },
 ]
 
 [[package]]
@@ -1098,6 +1150,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/bb/22/f1129e69d94ffff62
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/e7/df2285f3d08fee213f2d041540fa4fc9ca6c2d44cf36d3a035bf2a8d2bcc/pyparsing-3.2.3-py3-none-any.whl", hash = "sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf", size = 111120, upload-time = "2025-03-25T05:01:24.908Z" },
 ]
+
+[[package]]
+name = "pyswisseph"
+version = "2.10.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/a6/db70d67a00dda42ebd033538c086879328f4c17f670eafe8aca2f11abfef/pyswisseph-2.10.3.2.tar.gz", hash = "sha256:c54c305e83dbd5d2b71e58d8a69d8ee41de24c4d3328ce09e2af860a3537624d", size = 6940913, upload-time = "2023-06-04T17:05:53.293Z" }
 
 [[package]]
 name = "pytest"
@@ -1317,6 +1375,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pygments" },
     { name = "pyparsing" },
+    { name = "pyswisseph" },
     { name = "pytest" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
@@ -1348,6 +1407,11 @@ dependencies = [
     { name = "xxhash" },
     { name = "yarl" },
     { name = "zstandard" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
 ]
 
 [package.metadata]
@@ -1427,6 +1491,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = "==2.12.0" },
     { name = "pygments", specifier = "==2.19.2" },
     { name = "pyparsing", specifier = "==3.2.3" },
+    { name = "pyswisseph", specifier = ">=2.10.3.2" },
     { name = "pytest", specifier = "==8.4.2" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
     { name = "python-dotenv", specifier = "==1.1.1" },
@@ -1459,6 +1524,9 @@ requires-dist = [
     { name = "yarl", specifier = "==1.22.0" },
     { name = "zstandard", specifier = "==0.25.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "mypy", specifier = ">=1.20.2" }]
 
 [[package]]
 name = "setuptools"


### PR DESCRIPTION
…amework (#66)

- Replace Skyfield zodiac/aspect math with pyswisseph (Moshier ephemeris)
- Add whole-sign houses, natal chart, planetary dignity, and transit hits
- Restructure LLM data payload with subject_natal and current_sky keys
- Update horoscope prompt to Hellenistic spec (grounded language, house references)
- Remove section title from Sky Highlights renderer