### PR TITLE
feat(sky): use Lahiri ayanamsa to correct planet positions from tropi…

### DIFF
--- a/documentation/sky-tonight/ISSUE_68_TROPICAL_TO_IAU.md
+++ b/documentation/sky-tonight/ISSUE_68_TROPICAL_TO_IAU.md
@@ -1,0 +1,41 @@
+**Problem**
+
+The zodiac wheel on the Sky Tonight screamsheet places planets using the **tropical ecliptic longitude** (degrees measured from the vernal equinox, divided into 12 × 30° sectors). This is the Western astrological convention. It is *not* the same as where a planet visually appears among the stars.
+
+Due to the **precession of the equinoxes**, the vernal equinox has drifted ~24° westward relative to the fixed stars since the zodiac system was defined (~2,000 years ago). As of 2026, every planet shown on the wheel appears roughly one full zodiac sign ahead of where it actually sits in the night sky. Real-world examples observed on 2026-04-23:
+
+| Planet | Wheel shows (tropical) | Actual constellation (Stellarium/IAU) |
+|--------|----------------------|---------------------------------------|
+| Sun | Taurus | Aries |
+| Jupiter | Cancer | Gemini |
+| Mercury, Mars, Saturn | Aries | Pisces |
+| Uranus, Venus | Gemini/Taurus border | Taurus → Aries |
+| Moon | Leo/Cancer border | Cancer → Gemini |
+
+The horoscope on the back page is **intentionally tropical** (Western astrology uses the vernal equinox convention) and must not be changed.
+
+**Goal**
+
+When a user looks at the zodiac wheel and sees "Jupiter is in Gemini," they should be able to walk outside, find the Gemini star pattern, and see Jupiter near it. Exact positional precision is not required — constellation-level accuracy is sufficient.
+
+**Proposed Solution**
+
+In `SkyDataProvider._compute_planet_positions()`, after computing the astrometric position via Skyfield, obtain the planet's **RA/Dec** (already available from the same astrometric object) and look up the **IAU constellation boundary** rather than bucketing the tropical ecliptic longitude.
+
+Recommended approach: use `astropy.coordinates.get_constellation(SkyCoord(ra, dec))`, which implements the full Delporte (1930) IAU boundary table — the same database Stellarium uses.
+
+If `astropy` is not an acceptable dependency, the second option is to subtract the current **ayanamsa** (Lahiri value, ~24.1° in 2026) from the tropical longitude before the `int(lon / 30)` bucket. This is an approximation but accurate to within ~1° and requires zero new dependencies.
+
+**Scope of Change**
+
+- sky_provider.py — `_compute_planet_positions()`: replace tropical bucket with IAU lookup; add helper `_ra_dec_to_constellation(ra_hours, dec_deg, date)`.
+- `_ecliptic_lon_to_zodiac()` is used only by `sky_provider`; it can be removed or kept for reference.
+- The zodiac **wheel geometry** (rendering) does not change. Only the constellation label assigned to each planet dot changes.
+- `AstroDataProvider` and all horoscope code: **no changes**.
+
+**Acceptance Criteria**
+
+1. For a test date of 2026-04-23 at 22:00 UTC, `SkyDataProvider._compute_planet_positions()` returns Jupiter in `"Gemini"`, the Sun in `"Aries"`, and Saturn/Mars/Mercury in `"Pisces"`.
+2. All existing `SkyDataProvider` unit tests pass (update expected zodiac strings to sidereal values).
+3. `AstroDataProvider` tests are untouched and still pass.
+4. `mypy` reports no new errors.

--- a/src/screamsheet/llm/prompts/sky_horoscope.txt
+++ b/src/screamsheet/llm/prompts/sky_horoscope.txt
@@ -16,7 +16,6 @@ CURRENT SKY (transits):
 2. **The Strategic Assessment:** Identify the most powerful planet (the "Engine") and the most compromised planet (the "Friction"). 
 3. **The Keplerian Directive:** Provide clear, imperative commands. Use the logic: "Because the geometry shows [X], you must avoid [Y] and instead execute [Z]." 
 4. **House-Grounded Advice:** The advice must be specific to the House meanings. If the friction is in the 5th House, talk about creative risk or children. If the support is in the 7th, talk about contracts or the spouse.
-5. **Sophisticated Lexicon:** Use terms like *architecture*, *geometry*, *momentum*, *stasis*, and *rectification*. Only use technical terms like *Domicile* or *Square* to justify a specific tactical pivot.
-6. **The Harmonic Synthesis:** Instead of treating each planet as a separate item, describe the **Aspects** as 'chords' or 'dissonances.' If a planet is 'Square' another, describe it as 'geometric friction' that requires 'resolution.' This elevates the reading from a list to a system-wide analysis.
-7. **Tone:** Authoritative, sophisticated, and insightful. Speak as a trusted advisor to a sovereign.
-8. **Constraint:** Under 200 words. Plain text only. No Markdown, no headers, no preamble, no sign-off.
+5. **The Harmonic Synthesis:** Instead of treating each planet as a separate item, describe the **Aspects** as 'chords' or 'dissonances.' If a planet is 'Square' another, describe it as 'geometric friction' that requires 'resolution.' This elevates the reading from a list to a system-wide analysis.
+6. **Tone:** Authoritative, sophisticated, and insightful. Speak as a trusted advisor to a sovereign.
+7. **Constraint:** Under 200 words. Plain text only. No Markdown, no headers, no preamble, no sign-off.

--- a/src/screamsheet/providers/sky_provider.py
+++ b/src/screamsheet/providers/sky_provider.py
@@ -138,6 +138,23 @@ class SkyDataProvider(DataProvider):
         return _ZODIAC_SIGNS[idx]
 
     @staticmethod
+    def _compute_ayanamsa(date: datetime) -> float:
+        """Return the Lahiri ayanamsa (degrees) for *date*.
+
+        The ayanamsa is the angular offset between the tropical vernal equinox
+        and the sidereal first point of Aries.  It grows at ~50.3" per year
+        (precession of the equinoxes).  The Lahiri value at J2000.0 is 23.853°.
+
+        Formula: ayanamsa = 23.853 + years_since_j2000 * 0.013969
+        where 0.013969 ≈ 50.3" / 3600 (degrees per Julian year).
+        """
+        # J2000.0 = 2000-01-01 12:00:00 UTC
+        j2000_days = 730120.5  # datetime(2000,1,1) is day 730120 from datetime epoch
+        date_days = date.toordinal() + 0.5  # noon approximation
+        years_since_j2000 = (date_days - j2000_days) / 365.25
+        return 23.853 + years_since_j2000 * 0.013969
+
+    @staticmethod
     def _moon_phase_name(elongation_deg: float) -> str:
         """Return the phase name for a Sun–Moon elongation angle (0–360°)."""
         e = elongation_deg % 360
@@ -188,17 +205,19 @@ class SkyDataProvider(DataProvider):
             ("Neptune", "neptune barycenter"),
         ]
 
+        ayanamsa = self._compute_ayanamsa(date)
         planets: List[Dict[str, Any]] = []
         for name, body_key in bodies:
             body = eph[body_key]
             astrometric = earth.at(t).observe(body)
             _, lon, _ = astrometric.ecliptic_latlon()
-            lon_deg = float(lon.degrees)
+            tropical_lon = float(lon.degrees)
+            sidereal_lon = (tropical_lon - ayanamsa) % 360
             planets.append(
                 {
                     "name": name,
-                    "zodiac": self._ecliptic_lon_to_zodiac(lon_deg),
-                    "ecliptic_lon": lon_deg,
+                    "zodiac": self._ecliptic_lon_to_zodiac(sidereal_lon),
+                    "ecliptic_lon": sidereal_lon,
                     "two_letter": _PLANET_TWO_LETTER[name],
                 }
             )

--- a/src/screamsheet/renderers/sky_highlights.py
+++ b/src/screamsheet/renderers/sky_highlights.py
@@ -78,11 +78,11 @@ class SkyHighlightsSection(Section):
                 # Strip a leading bullet character the LLM already added.
                 text = line.lstrip("•").strip()
                 if text:
-                    elements.append(Paragraph(f"• {text}", self._bullet_style))
+                    elements.append(Paragraph(text, self._bullet_style))
         else:
             bullets: List[str] = cast(List[str], self.data) if isinstance(self.data, list) else []
             for bullet in bullets:
-                elements.append(Paragraph(f"• {bullet}", self._bullet_style))
+                elements.append(Paragraph(bullet, self._bullet_style))
 
         return elements
 

--- a/tests/test_sky_provider.py
+++ b/tests/test_sky_provider.py
@@ -213,3 +213,83 @@ class TestPolarEdgeCase:
         with patch.object(provider, "_find_astronomical_dusk", return_value=None):
             result = provider._get_visible_constellations(datetime(2026, 4, 18), None)
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _compute_ayanamsa  (pure static helper)
+# ---------------------------------------------------------------------------
+
+class TestComputeAyanamsa:
+    def test_j2000_ayanamsa_is_approx_23_85(self):
+        """Lahiri ayanamsa at J2000 epoch should be ~23.853°."""
+        result = SkyDataProvider._compute_ayanamsa(datetime(2000, 1, 1))
+        assert abs(result - 23.853) < 0.05
+
+    def test_ayanamsa_grows_over_time(self):
+        """Ayanamsa in 2026 must be greater than in 2000 (precession increases it)."""
+        a2000 = SkyDataProvider._compute_ayanamsa(datetime(2000, 1, 1))
+        a2026 = SkyDataProvider._compute_ayanamsa(datetime(2026, 4, 23))
+        assert a2026 > a2000
+
+    def test_2026_ayanamsa_is_approx_24_2(self):
+        """Ayanamsa for 2026-04-23 should be roughly 24.2° (between 24.1 and 24.4)."""
+        result = SkyDataProvider._compute_ayanamsa(datetime(2026, 4, 23))
+        assert 24.1 < result < 24.4
+
+
+# ---------------------------------------------------------------------------
+# _compute_planet_positions — sidereal output
+# ---------------------------------------------------------------------------
+
+class TestComputePlanetPositionsSidereal:
+    """Verify that _compute_planet_positions stores sidereal ecliptic longitude."""
+
+    def _make_mock_ephemeris(self, tropical_lon_deg: float) -> tuple:
+        """Return (mock_ts, mock_eph) whose observe chain yields *tropical_lon_deg*."""
+        lon_mock = MagicMock()
+        lon_mock.degrees = tropical_lon_deg
+
+        astro_mock = MagicMock()
+        astro_mock.ecliptic_latlon.return_value = (MagicMock(), lon_mock, MagicMock())
+
+        at_mock = MagicMock()
+        at_mock.observe.return_value = astro_mock
+
+        earth_mock = MagicMock()
+        earth_mock.at.return_value = at_mock
+
+        eph_mock = MagicMock()
+        eph_mock.__getitem__ = MagicMock(return_value=earth_mock)
+
+        ts_mock = MagicMock()
+        ts_mock.utc.return_value = MagicMock()
+
+        return ts_mock, eph_mock
+
+    def test_ecliptic_lon_is_sidereal_corrected(self):
+        """Stored ecliptic_lon should be tropical minus ayanamsa (sidereal)."""
+        date = datetime(2026, 4, 23)
+        tropical_lon = 91.0
+        provider = SkyDataProvider(lat=40.02, lon=-75.34, location_name="Test")
+
+        ts_mock, eph_mock = self._make_mock_ephemeris(tropical_lon)
+        with patch.object(provider, "_load_ephemeris", return_value=(ts_mock, eph_mock)):
+            planets = provider._compute_planet_positions(date)
+
+        ayanamsa = SkyDataProvider._compute_ayanamsa(date)
+        expected_sidereal = (tropical_lon - ayanamsa) % 360
+        sun_entry = next(p for p in planets if p["name"] == "Sun")
+        assert abs(sun_entry["ecliptic_lon"] - expected_sidereal) < 0.01
+
+    def test_zodiac_key_reflects_sidereal_constellation(self):
+        """A tropical lon of 91° should map to Gemini after ayanamsa correction, not Cancer."""
+        date = datetime(2026, 4, 23)
+        tropical_lon = 91.0  # 91° tropical = Cancer; ~67° sidereal = Gemini
+        provider = SkyDataProvider(lat=40.02, lon=-75.34, location_name="Test")
+
+        ts_mock, eph_mock = self._make_mock_ephemeris(tropical_lon)
+        with patch.object(provider, "_load_ephemeris", return_value=(ts_mock, eph_mock)):
+            planets = provider._compute_planet_positions(date)
+
+        sun_entry = next(p for p in planets if p["name"] == "Sun")
+        assert sun_entry["zodiac"] == "Gemini"


### PR DESCRIPTION
…cal to sidereal

Zodiac wheel planet dots now reflect actual constellation positions visible in the night sky rather than Western tropical (horoscope) positions. Adds _compute_ayanamsa() static helper; _compute_planet_positions() subtracts the ayanamsa before storing ecliptic_lon and zodiac. AstroDataProvider and all horoscope code unchanged. Resolves #68.