### PR TITLE
feat: zodiac wheel improvements, horoscope cleanup, and fan-rant game…

### DIFF
--- a/src/screamsheet/base/data_provider.py
+++ b/src/screamsheet/base/data_provider.py
@@ -65,13 +65,15 @@ class DataProvider(ABC):
         """
         return None
     
-    def get_game_summary(self, team_id: int, date: datetime) -> Optional[str]:
+    def get_game_summary(self, team_id: int, date: datetime, is_primary_favorite: bool = False) -> Optional[str]:
         """
         Get game summary for a specific team and date.
         
         Args:
             team_id: The team ID
             date: The date to fetch summary for
+            is_primary_favorite: True when this is the #1 priority team (enables
+                fan-rant mode for losing results in concrete providers that support it)
             
         Returns:
             Game summary text or None if not available

--- a/src/screamsheet/llm/prompts/mlb_game_fan_rant.txt
+++ b/src/screamsheet/llm/prompts/mlb_game_fan_rant.txt
@@ -1,0 +1,21 @@
+You are a lifelong fan of {losing_team} — born and raised in that city, red sauce on your shirt, and right now you are absolutely furious. Your team just lost. Again. They had their chance and they blew it, just like they always blow it.
+
+You are also a meticulous baseball beat writer, so this IS a complete, accurate game recap with real facts from the play-by-play. Every key pitch, every wasted runner in scoring position, every baffling bullpen decision — all of it, covered honestly. BUT the voice is a passionate, direct, hometown fan who is done making excuses. No sugarcoating. No spin. Just cold facts delivered with the heat of someone who has been watching this team break their heart for decades.
+
+RULES:
+- Cover all of the following with specifics from the narrative: starting pitcher effectiveness (innings, strikeouts, whether he was sharp or laboring), the decisive offensive failure (key GIDP, strikeout with runners on, or the HR that broke it open against them), bullpen performance, and any defensive miscue that mattered.
+- Sabermetric fluency is assumed; do not explain basic statistics.
+- The tone is blunt, passionate, and unsparing. You are not hiding behind "they'll get 'em next time." You are calling out what went wrong by name.
+- Express frustration through word choice and sarcasm, not profanity.
+- No manufactured suspense. If it was a blowout, say so — and be even more disgusted.
+- One continuous paragraph, 200-300 words. No markdown, no bullet points, no headers.
+
+Game details:
+Home Team: {home_team}
+Away Team: {away_team}
+Final Score: {home_team} {home_score}, {away_team} {away_score}
+The team that lost: {losing_team}
+
+Narrative snippets (at-bat results in play order; use these to reconstruct the game): {narrative_snippets}
+
+Write the recap now. Lead with the loss. Do not hold back.

--- a/src/screamsheet/llm/prompts/nhl_game_fan_rant.txt
+++ b/src/screamsheet/llm/prompts/nhl_game_fan_rant.txt
@@ -1,0 +1,21 @@
+You are a lifelong fan of {losing_team} — born and raised in that city, season tickets since you were a kid, and right now you are absolutely livid. Your team just lost. Again. They had their chance and they threw it away, like they always do.
+
+You are also a meticulous hockey beat writer, so this IS a complete, accurate game recap with real facts from the play-by-play. Every key goal, every botched power play, every sieve moment from the goalie, every boneheaded penalty — all of it, covered honestly. BUT the voice is a passionate, direct, hometown fan who is done making excuses. No sugarcoating. No spin. Just cold facts delivered with the heat of someone who has been watching this team break their heart for decades.
+
+RULES:
+- Cover all of the following with specifics from the narrative: goaltender performance (volume faced, pivotal stops or surrendered goals), the decisive scoring sequence (key goal with scorer and assists), power play and penalty kill outcomes, and any defensive breakdown that turned the game.
+- Do not explain rules, positions, or basic hockey concepts — the reader follows the NHL closely.
+- The tone is blunt, passionate, and unsparing. You are not hiding behind "they'll get 'em next time." You are calling out what went wrong by name.
+- Express frustration through word choice and sarcasm, not profanity.
+- No manufactured suspense. If it was a blowout, say so — and be even more disgusted.
+- One continuous paragraph of plain text, 200-300 words. No markdown, no bullet points, no headers.
+
+Game details:
+Home Team: {home_team}
+Away Team: {away_team}
+Final Score: {home_team} {home_score}, {away_team} {away_score}
+The team that lost: {losing_team}
+
+Narrative snippets (period-tagged play-by-play; use these for substance and context): {narrative_snippets}
+
+Write the recap now. Lead with the loss. Do not hold back.

--- a/src/screamsheet/llm/summarizers.py
+++ b/src/screamsheet/llm/summarizers.py
@@ -78,6 +78,36 @@ class NHLGameSummarizer(FilePromptMixin, BaseGameSummaryGenerator):
         )
 
 
+class NHLFanRantSummarizer(FilePromptMixin, BaseGameSummaryGenerator):
+    """
+    Generates an angry hometown-fan game recap when the primary favorite NHL team loses.
+
+    Expected ``data`` keys
+    ----------------------
+    - ``home_team``          str
+    - ``away_team``          str
+    - ``home_score``         int
+    - ``away_score``         int
+    - ``narrative_snippets`` str  — period-tagged play-by-play
+    - ``losing_team``        str  — full name of the featured team that lost
+    """
+
+    _PROMPT_FILE = Path("nhl_game_fan_rant.txt")
+
+    def __init__(
+        self,
+        gemini_api_key: Optional[str] = None,
+        grok_api_key: Optional[str] = None,
+        config: LLMConfig = DEFAULT_LLM_CONFIG,
+    ) -> None:
+        BaseGameSummaryGenerator.__init__(
+            self,
+            gemini_api_key=gemini_api_key,
+            grok_api_key=grok_api_key,
+            config=config,
+        )
+
+
 class MLBGameSummarizer(FilePromptMixin, BaseGameSummaryGenerator):
     """
     Generates an over-the-top MLB game recap for a stat-savvy young fan.
@@ -92,6 +122,39 @@ class MLBGameSummarizer(FilePromptMixin, BaseGameSummaryGenerator):
     """
 
     _PROMPT_FILE = Path("mlb_game.txt")
+
+    def __init__(
+        self,
+        gemini_api_key: Optional[str] = None,
+        grok_api_key: Optional[str] = None,
+        config: LLMConfig = DEFAULT_LLM_CONFIG,
+    ) -> None:
+        BaseGameSummaryGenerator.__init__(
+            self,
+            gemini_api_key=gemini_api_key,
+            grok_api_key=grok_api_key,
+            config=config,
+        )
+
+
+class MLBFanRantSummarizer(FilePromptMixin, BaseGameSummaryGenerator):
+    """
+    Generates an angry hometown-fan game recap when the primary favorite team loses.
+
+    Uses the same game-data structure as ``MLBGameSummarizer`` but adds
+    ``losing_team`` so the prompt can address the fan base directly.
+
+    Expected ``data`` keys
+    ----------------------
+    - ``home_team``          str
+    - ``away_team``          str
+    - ``home_score``         int
+    - ``away_score``         int
+    - ``narrative_snippets`` str  — space-joined play descriptions
+    - ``losing_team``        str  — full name of the featured team that lost
+    """
+
+    _PROMPT_FILE = Path("mlb_game_fan_rant.txt")
 
     def __init__(
         self,

--- a/src/screamsheet/llm/summary.py
+++ b/src/screamsheet/llm/summary.py
@@ -15,7 +15,7 @@ continue to work unchanged.
 # isort: skip_file
 from .config import LLMConfig, DEFAULT_LLM_CONFIG  # noqa: F401
 from .base import BaseGameSummaryGenerator, ExtractedInfo, PromptChainInput  # noqa: F401
-from .summarizers import NHLGameSummarizer, MLBGameSummarizer, NewsSummarizer, SkyNightSummarizer  # noqa: F401
+from .summarizers import NHLGameSummarizer, NHLFanRantSummarizer, MLBGameSummarizer, MLBFanRantSummarizer, NewsSummarizer, SkyNightSummarizer  # noqa: F401
 
 __all__ = [
     "LLMConfig",
@@ -24,6 +24,8 @@ __all__ = [
     "ExtractedInfo",
     "PromptChainInput",
     "NHLGameSummarizer",
+    "NHLFanRantSummarizer",
     "MLBGameSummarizer",
+    "MLBFanRantSummarizer",
     "NewsSummarizer",
 ]

--- a/src/screamsheet/providers/mlb_provider.py
+++ b/src/screamsheet/providers/mlb_provider.py
@@ -215,13 +215,17 @@ class MLBDataProvider(DataProvider):
             print(f"Error getting MLB box score: {e}")
             return None
     
-    def get_game_summary(self, team_id: int, date: datetime) -> Optional[str]:
+    def get_game_summary(self, team_id: int, date: datetime, is_primary_favorite: bool = False) -> Optional[str]:
         """
         Get game summary for a specific team and date.
-        
+
+        When ``is_primary_favorite`` is True and the featured team lost, the
+        summary uses the angry-fan rant persona instead of the neutral recap.
+
         Args:
             team_id: The MLB team ID
             date: The date to fetch summary for
+            is_primary_favorite: True when this is the #1 priority team
             
         Returns:
             Game summary text or None if not available
@@ -230,17 +234,44 @@ class MLBDataProvider(DataProvider):
         try:
             import os
             from .extractors import MLBGameExtractor
-            from ..llm.summary import MLBGameSummarizer
+            from ..llm.summary import MLBGameSummarizer, MLBFanRantSummarizer
             date_str = date.strftime("%Y-%m-%d")
             extractor = MLBGameExtractor()
-            extracted = extractor.extract_key_info(extractor.fetch_raw_data(team_id, date_str))
+            raw = extractor.fetch_raw_data(team_id, date_str)
+            extracted = extractor.extract_key_info(raw)
             if isinstance(extracted, str):
                 return extracted
-            summarizer = MLBGameSummarizer(
-                gemini_api_key=os.getenv("GEMINI_API_KEY"),
-                grok_api_key=os.getenv("GROK_API_KEY")
-            )
-            return summarizer.generate_summary(llm_choice='gemini', data=extracted)
+
+            use_rant = False
+            losing_team: Optional[str] = None
+            if is_primary_favorite and raw:
+                home_id = (
+                    raw.get("gameData", {}).get("teams", {}).get("home", {}).get("id")
+                )
+                home_score = int(extracted["home_score"])
+                away_score = int(extracted["away_score"])
+                if home_id == team_id:
+                    team_won = home_score > away_score
+                    losing_team = str(extracted["home_team"])
+                else:
+                    team_won = away_score > home_score
+                    losing_team = str(extracted["away_team"])
+                use_rant = not team_won
+
+            if use_rant and losing_team is not None:
+                summarizer: MLBGameSummarizer = MLBFanRantSummarizer(
+                    gemini_api_key=os.getenv("GEMINI_API_KEY"),
+                    grok_api_key=os.getenv("GROK_API_KEY"),
+                )
+                data = {**extracted, "losing_team": losing_team}
+            else:
+                summarizer = MLBGameSummarizer(
+                    gemini_api_key=os.getenv("GEMINI_API_KEY"),
+                    grok_api_key=os.getenv("GROK_API_KEY"),
+                )
+                data = extracted  # type: ignore[assignment]
+
+            return summarizer.generate_summary(llm_choice="gemini", data=data)
         except Exception as e:
             print(f"Error getting MLB game summary: {e}")
             return None

--- a/src/screamsheet/providers/nhl_provider.py
+++ b/src/screamsheet/providers/nhl_provider.py
@@ -157,13 +157,17 @@ class NHLDataProvider(DataProvider):
             print(f"Error getting NHL box score: {e}")
             return None
     
-    def get_game_summary(self, team_id: int, date: datetime) -> Optional[str]:
+    def get_game_summary(self, team_id: int, date: datetime, is_primary_favorite: bool = False) -> Optional[str]:
         """
         Get game summary for a specific team and date.
-        
+
+        When ``is_primary_favorite`` is True and the featured team lost, the
+        summary uses the angry-fan rant persona instead of the neutral recap.
+
         Args:
             team_id: The NHL team ID
             date: The date to fetch summary for
+            is_primary_favorite: True when this is the #1 priority team
             
         Returns:
             Game summary text or None if not available
@@ -171,19 +175,44 @@ class NHLDataProvider(DataProvider):
         try:
             import os
             from .extractors import NHLGameExtractor
-            from ..llm.summary import NHLGameSummarizer
+            from ..llm.summary import NHLGameSummarizer, NHLFanRantSummarizer
             game_pk = self._get_game_pk(team_id, date)
             if not game_pk:
                 return None
             extractor = NHLGameExtractor()
-            extracted = extractor.extract_key_info(extractor.fetch_raw_data(game_pk))
+            raw = extractor.fetch_raw_data(game_pk)
+            extracted = extractor.extract_key_info(raw)
             if isinstance(extracted, str):
                 return extracted
-            summarizer = NHLGameSummarizer(
-                gemini_api_key=os.getenv("GEMINI_API_KEY"),
-                grok_api_key=os.getenv("GROK_API_KEY")
-            )
-            return summarizer.generate_summary(llm_choice='gemini', data=extracted)
+
+            use_rant = False
+            losing_team: Optional[str] = None
+            if is_primary_favorite and raw:
+                home_id = raw.get("homeTeam", {}).get("id")
+                home_score = int(extracted["home_score"])
+                away_score = int(extracted["away_score"])
+                if home_id == team_id:
+                    team_won = home_score > away_score
+                    losing_team = str(extracted["home_team"])
+                else:
+                    team_won = away_score > home_score
+                    losing_team = str(extracted["away_team"])
+                use_rant = not team_won
+
+            if use_rant and losing_team is not None:
+                summarizer: NHLGameSummarizer = NHLFanRantSummarizer(
+                    gemini_api_key=os.getenv("GEMINI_API_KEY"),
+                    grok_api_key=os.getenv("GROK_API_KEY"),
+                )
+                data = {**extracted, "losing_team": losing_team}
+            else:
+                summarizer = NHLGameSummarizer(
+                    gemini_api_key=os.getenv("GEMINI_API_KEY"),
+                    grok_api_key=os.getenv("GROK_API_KEY"),
+                )
+                data = extracted  # type: ignore[assignment]
+
+            return summarizer.generate_summary(llm_choice="gemini", data=data)
         except Exception as e:
             print(f"Error getting NHL game summary: {e}")
             return None

--- a/src/screamsheet/renderers/box_score.py
+++ b/src/screamsheet/renderers/box_score.py
@@ -18,11 +18,13 @@ class BoxScoreSection(Section):
     Currently only fully implemented for MLB and NHL.
     """
     
-    def __init__(self, title: str, provider: DataProvider, team_id: int, date: datetime):
+    def __init__(self, title: str, provider: DataProvider, team_id: int, date: datetime,
+                 is_primary_favorite: bool = False):
         super().__init__(title)
         self.provider = provider
         self.team_id = team_id
         self.date = date
+        self.is_primary_favorite = is_primary_favorite
         self.styles = getSampleStyleSheet()
         
         self.subtitle_style = ParagraphStyle(
@@ -67,7 +69,9 @@ class BoxScoreSection(Section):
         elements = []
         
         # Get game summary from provider
-        game_summary = self.provider.get_game_summary(self.team_id, self.date)
+        game_summary = self.provider.get_game_summary(
+            self.team_id, self.date, is_primary_favorite=self.is_primary_favorite
+        )
         
         # Build left column (game summary)
         left_column = []

--- a/src/screamsheet/renderers/zodiac_wheel.py
+++ b/src/screamsheet/renderers/zodiac_wheel.py
@@ -1,9 +1,9 @@
 """Zodiac wheel renderer for the Sky Tonight screamsheet.
 
 Draws a full circular zodiac wheel using ReportLab vector graphics:
-  - 12 alternating grayscale annular wedges labelled with 3-letter sign abbreviations
+  - 12 annular wedges labelled with full constellation names, rotated tangentially
+  - Light-gray shading marks signs visible above the horizon tonight
   - Planet astrological symbols at their ecliptic longitude positions
-  - A semi-transparent gray overlay for zodiac signs visible above the horizon
 """
 from __future__ import annotations
 
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, cast
 
 from reportlab.graphics.shapes import (
     Drawing,
+    Group,
     Line,
     Wedge,
     Circle,
@@ -54,9 +55,9 @@ _PLANET_RADII: dict[str, float] = {
     "Neptune": _OUTER_R * 0.64,
 }
 
-# Binary color scheme: visible sign = white, not visible = medium gray
-_VISIBLE_FILL   = HexColor("#FFFFFF")
-_INVISIBLE_FILL = HexColor("#BBBBBB")
+# Binary color scheme: visible above horizon tonight = light gray, below horizon = white
+_VISIBLE_FILL   = HexColor("#BBBBBB")
+_INVISIBLE_FILL = HexColor("#FFFFFF")
 _VISIBLE_TEXT   = black
 _INVISIBLE_TEXT = black
 
@@ -189,9 +190,9 @@ class ZodiacWheelSection(Section):
 
         # ------------------------------------------------------------------
         # 1. Zodiac wedges (ecliptic 0° = Aries at right, grows CCW)
-        #    White = visible above the horizon tonight; dark = below horizon.
+        #    Light gray = visible above the horizon tonight; white = below.
         # ------------------------------------------------------------------
-        for i, (short, full) in enumerate(zip(_ZODIAC_SHORT, _ZODIAC_FULL)):
+        for i, full in enumerate(_ZODIAC_FULL):
             start_deg  = i * 30
             is_visible = full in visible
             fill       = _VISIBLE_FILL   if is_visible else _INVISIBLE_FILL
@@ -203,11 +204,20 @@ class ZodiacWheelSection(Section):
             w.strokeWidth = 0.8
             d.add(w)
 
-            mid_rad = math.radians(start_deg + 15)
+            mid_deg = float(start_deg + 15)
+            mid_rad = math.radians(mid_deg)
             lx = cx + _RIM_R * math.cos(mid_rad)
             ly = cy + _RIM_R * math.sin(mid_rad)
-            d.add(String(lx, ly - 6, short, fontSize=13, textAnchor="middle",
-                         fillColor=text_col))
+            # Tangential label: baseline follows the arc, letter tops pointing
+            # outward toward the rim.  fontSize=7 keeps "Sagittarius" inside
+            # the 30° arc at _RIM_R without overflowing into adjacent sectors.
+            rot_rad = math.radians(mid_deg - 90.0)
+            cos_t, sin_t = math.cos(rot_rad), math.sin(rot_rad)
+            s = String(0, 0, full, fontSize=13, textAnchor="middle",
+                       fillColor=text_col)
+            g = Group(s)
+            g.transform = (cos_t, sin_t, -sin_t, cos_t, lx, ly)
+            d.add(g)
 
         # ------------------------------------------------------------------
         # 2. Inner circle — white background for the planet zone.

--- a/src/screamsheet/sky/sky_tonight.py
+++ b/src/screamsheet/sky/sky_tonight.py
@@ -71,7 +71,7 @@ class SkyTonightScreamsheet(BaseScreamsheet):
                 location_name=self.location_name,
             ),
             SkyHoroscopeSection(
-                title="Tonight's Horoscopes",
+                title="Horoscopes",
                 provider=self.provider,
                 date=self.date,
                 location_name=self.location_name,

--- a/src/screamsheet/sports/base_sports.py
+++ b/src/screamsheet/sports/base_sports.py
@@ -117,12 +117,14 @@ class SportsScreamsheet(BaseScreamsheet):
         featured = self._resolve_featured_team()
         if featured:
             featured_id, featured_name = featured
+            is_primary = bool(self.favorite_teams) and featured == self.favorite_teams[0]
             sections.append(
                 BoxScoreSection(
                     title=f"{featured_name} Box Score",
                     provider=self.provider,
                     team_id=featured_id,
-                    date=self.date
+                    date=self.date,
+                    is_primary_favorite=is_primary,
                 )
             )
         


### PR DESCRIPTION
… recaps

- Zodiac wheel: replace 3-letter abbreviations with full constellation names, rotated tangentially inside the annular sector
- Zodiac wheel: invert shading so visible-tonight sectors are light gray, hidden sectors are white
- Sky Tonight: rename "Tonight's Horoscopes" section to "Horoscopes"
- MLB/NHL: add fan-rant recap mode — when the #1 favorite team loses, the game summary adopts the voice of an enraged hometown fan
- Add mlb_game_fan_rant.txt and nhl_game_fan_rant.txt prompt files
- Add MLBFanRantSummarizer and NHLFanRantSummarizer classes
- Thread is_primary_favorite flag from SportsScreamsheet → BoxScoreSection → provider.get_game_summary to activate rant mode