### PR TITLE
feat(nba): complete NBA screamsheet back page with box score and LLM …

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -30,6 +30,10 @@ nba:
   favorite_teams:
     - id: 1610612755
       name: "Philadelphia 76ers"
+    - id: 1610612752
+      name: "New York Knicks"
+    - id: 1610612749
+      name: "Milwaukee Bucks"
 
 nfl:
   favorite_teams:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -35,6 +35,10 @@ nba:
   favorite_teams:
     - id: 1610612755
       name: "Philadelphia 76ers"
+    - id: 1610612752
+      name: "New York Knicks"
+    - id: 1610612749
+      name: "Milwaukee Bucks"
 
 nfl:
   favorite_teams:

--- a/screamsheet.sh
+++ b/screamsheet.sh
@@ -41,6 +41,7 @@ print_sheet() {
 #    __main__.py produces:
 #      ../Files/MLB_gamescores_YYYYMMDD.pdf
 #      ../Files/NHL_gamescores_YYYYMMDD.pdf
+#      ../Files/NBA_gamescores_YYYYMMDD.pdf
 #      ../Files/MLB_trade_rumors_YYYYMMDD.pdf
 #      ../Files/MLB_NEWS_YYYYMMDD.pdf
 #      ../Files/presidential_screamsheet_YYYYMMDD.pdf
@@ -63,6 +64,7 @@ echo "[$(date +%T)] Generation phase complete. Starting print jobs..." >> "$LOG_
 # ---------------------------------------------------------------------------
 print_sheet "MLB Game Scores"          "./Files/MLB_gamescores_${DATE}.pdf"
 print_sheet "NHL Game Scores"          "./Files/NHL_gamescores_${DATE}.pdf"
+print_sheet "NBA Game Scores"          "./Files/NBA_gamescores_${DATE}.pdf"
 print_sheet "MLB Trade Rumors"         "./Files/MLB_trade_rumors_${DATE}.pdf"
 print_sheet "MLB News"                 "./Files/MLB_NEWS_${DATE}.pdf"
 print_sheet "Presidential Screamsheet" "./Files/presidential_screamsheet_${DATE}.pdf"

--- a/src/screamsheet/__main__.py
+++ b/src/screamsheet/__main__.py
@@ -2,10 +2,13 @@
 Main entry point for the screamsheet system.
 
 Usage:
-    uv run python -m screamsheet            # run all screamsheets
-    uv run python -m screamsheet --single   # pick one interactively and run it
+    uv run screamsheet                         # run all (yesterday's games)
+    uv run screamsheet --single                # pick one interactively
+    uv run screamsheet --date 20260503         # treat May 3 as today (fetches May 2 games)
+    uv run screamsheet --single --date 20260503
 """
 import argparse
+import logging
 from datetime import datetime, timedelta
 from .factory import ScreamsheetFactory
 from .config import load_config
@@ -35,6 +38,7 @@ def _build_sheets(today_str: str) -> list:
     cfg = load_config()
     mlb_teams = [(t.id, t.name) for t in cfg.mlb.favorite_teams]
     nhl_teams = [(t.id, t.name) for t in cfg.nhl.favorite_teams]
+    nba_teams = [(t.id, t.name) for t in cfg.nba.favorite_teams]
     mlb_news_names = cfg.mlb.news_names
 
     return [        (
@@ -76,6 +80,15 @@ def _build_sheets(today_str: str) -> list:
             lambda: ScreamsheetFactory.create_nhl_screamsheet(
                 output_filename=f'Files/NHL_gamescores_{today_str}.pdf',
                 favorite_teams=nhl_teams,
+                date=game_date,
+                display_date=today,
+            ),
+        ),
+        (
+            "NBA  — " + (cfg.nba.favorite_teams[0].name if cfg.nba.favorite_teams else ""),
+            lambda: ScreamsheetFactory.create_nba_screamsheet(
+                output_filename=f'Files/NBA_gamescores_{today_str}.pdf',
+                favorite_teams=nba_teams,
                 date=game_date,
                 display_date=today,
             ),
@@ -131,6 +144,11 @@ def _pick_and_run(sheets: list) -> None:
 
 
 def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s  %(name)-40s  %(levelname)-8s  %(message)s",
+        datefmt="%H:%M:%S",
+    )
     parser = argparse.ArgumentParser(
         prog="python -m screamsheet",
         description="Generate screamsheet PDFs.",
@@ -140,9 +158,24 @@ def main():
         action="store_true",
         help="Interactively select and run a single screamsheet.",
     )
+    parser.add_argument(
+        "--date",
+        metavar="YYYYMMDD",
+        help=(
+            "Treat this date as 'today' (game data fetched for the day before). "
+            "Example: --date 20260503 fetches games from May 2 and stamps files with 20260503."
+        ),
+    )
     args = parser.parse_args()
 
-    today_str = datetime.now().strftime("%Y%m%d")
+    if args.date:
+        try:
+            today_str = datetime.strptime(args.date, "%Y%m%d").strftime("%Y%m%d")
+        except ValueError:
+            parser.error(f"--date must be in YYYYMMDD format, got: {args.date}")
+    else:
+        today_str = datetime.now().strftime("%Y%m%d")
+
     sheets = _build_sheets(today_str)
 
     if args.single:

--- a/src/screamsheet/factory.py
+++ b/src/screamsheet/factory.py
@@ -151,6 +151,7 @@ class ScreamsheetFactory:
         team_id: Optional[int] = None,
         team_name: Optional[str] = None,
         date: Optional[datetime] = None,
+        display_date: Optional[datetime] = None,
         favorite_teams: Optional[List[Tuple[int, str]]] = None,
     ) -> NBAScreamsheet:
         """
@@ -161,6 +162,7 @@ class ScreamsheetFactory:
             team_id: NBA team ID (deprecated — use favorite_teams)
             team_name: Team name (deprecated — use favorite_teams)
             date: Target date (defaults to yesterday)
+            display_date: Date shown in the subtitle header (defaults to date)
             favorite_teams: Priority-ordered list of (team_id, team_name) tuples.
             
         Returns:
@@ -171,6 +173,7 @@ class ScreamsheetFactory:
             team_id=team_id,
             team_name=team_name,
             date=date,
+            display_date=display_date,
             favorite_teams=favorite_teams,
         )
     

--- a/src/screamsheet/llm/__init__.py
+++ b/src/screamsheet/llm/__init__.py
@@ -6,7 +6,7 @@ Public API — prefer importing from here rather than from sub-modules::
 """
 from .config import LLMConfig, DEFAULT_LLM_CONFIG
 from .base import BaseGameSummaryGenerator, ExtractedInfo, PromptChainInput
-from .summarizers import NHLGameSummarizer, MLBGameSummarizer, NewsSummarizer, PoliticalNewsSummarizer, SkyNightSummarizer
+from .summarizers import NHLGameSummarizer, MLBGameSummarizer, NewsSummarizer, PoliticalNewsSummarizer, SkyNightSummarizer, NBAGameSummarizer, NBAFanRantSummarizer
 
 __all__ = [
     "LLMConfig",
@@ -19,4 +19,6 @@ __all__ = [
     "NewsSummarizer",
     "PoliticalNewsSummarizer",
     "SkyNightSummarizer",
+    "NBAGameSummarizer",
+    "NBAFanRantSummarizer",
 ]

--- a/src/screamsheet/llm/prompts/nba_game.txt
+++ b/src/screamsheet/llm/prompts/nba_game.txt
@@ -1,0 +1,35 @@
+You are a professional basketball writer producing a concise game recap in the style of
+The Athletic or ESPN. Your reader follows the NBA closely — do not explain rules,
+positions, or basic concepts.
+
+TONE AND EXCITEMENT:
+Calibrate your tone to match what the game actually delivered.
+- If the final margin is fifteen or more points and the narrative shows no lead
+  changes after the first quarter, write with composed, analytical confidence.
+  The game was not close; don't manufacture drama.
+- If the margin is ten points or fewer, or if the narrative shows multiple lead
+  changes, let the tension come through naturally.
+- If the game went to overtime, measured drama is warranted — but keep the prose
+  clean and controlled.
+Never use exclamation points, hyperbole, or filler enthusiasm phrases.
+
+CONTENT AND DENSITY:
+Pack the recap with substance. Where the narrative snippets support it, include:
+- Leading scorer(s) and their stat line (points, key shooting splits if notable)
+- A decisive sequence or run that swung the game
+- Free throw performance if it was a factor in the outcome
+- A brief note on which team controlled the pace or the boards
+- Clutch plays or collapses in the fourth quarter, if present
+
+FORMAT:
+One continuous paragraph of plain text, 200-300 words. No markdown, no bullet
+points, no bolding, no special formatting.
+
+Game details:
+Home Team: {home_team}
+Away Team: {away_team}
+Final Score: {home_team} {home_score}, {away_team} {away_score}
+
+Narrative snippets (quarter-tagged play-by-play; use these for substance and context): {narrative_snippets}
+
+Write the recap now.

--- a/src/screamsheet/llm/prompts/nba_game_fan_rant.txt
+++ b/src/screamsheet/llm/prompts/nba_game_fan_rant.txt
@@ -1,0 +1,33 @@
+You are a lifelong fan of {losing_team} — born and raised in that city, season tickets since
+you were old enough to sit in the upper deck, and right now you are absolutely livid. Your team
+just lost. Again. They had their shot and they threw it away, like they always do.
+
+You are also a meticulous basketball beat writer, so this IS a complete, accurate game recap
+with real facts from the play-by-play. Every missed free throw, every turnover in crunch time,
+every defensive breakdown, every boneheaded foul — all of it, covered honestly. BUT the voice
+is a passionate, direct, hometown fan who is done making excuses. No sugarcoating. No spin.
+Just cold facts delivered with the heat of someone who has been watching this team break their
+heart for years.
+
+RULES:
+- Cover all of the following with specifics from the narrative: the leading scorer(s) and
+  whether they showed up when it mattered, free throw shooting if it was a factor (call it out
+  by name), the turning point that handed the game away, and any defensive collapse that let the
+  opponent go on a run.
+- Do not explain rules, positions, or basic basketball concepts — the reader follows the NBA.
+- The tone is blunt, passionate, and unsparing. You are not hiding behind "we'll get 'em next
+  game." You are calling out what went wrong, specifically.
+- Express frustration through word choice and sarcasm, not profanity.
+- No manufactured suspense. If it was a blowout, say so — and be even more disgusted.
+- One continuous paragraph of plain text, 200-300 words. No markdown, no bullet points,
+  no headers.
+
+Game details:
+Home Team: {home_team}
+Away Team: {away_team}
+Final Score: {home_team} {home_score}, {away_team} {away_score}
+The team that lost: {losing_team}
+
+Narrative snippets (quarter-tagged play-by-play; use these for substance and context): {narrative_snippets}
+
+Write the recap now. Lead with the loss. Do not hold back.

--- a/src/screamsheet/llm/summarizers.py
+++ b/src/screamsheet/llm/summarizers.py
@@ -292,3 +292,62 @@ class HoroscopeSummarizer(FilePromptMixin, BaseGameSummaryGenerator):
             grok_api_key=grok_api_key,
             config=config,
         )
+
+
+class NBAGameSummarizer(FilePromptMixin, BaseGameSummaryGenerator):
+    """
+    Generates an Athletic/ESPN-style NBA game recap.
+
+    Expected ``data`` keys
+    ----------------------
+    - ``home_team``          str
+    - ``away_team``          str
+    - ``home_score``         int
+    - ``away_score``         int
+    - ``narrative_snippets`` str  — quarter-tagged play descriptions
+    """
+
+    _PROMPT_FILE = Path("nba_game.txt")
+
+    def __init__(
+        self,
+        gemini_api_key: Optional[str] = None,
+        grok_api_key: Optional[str] = None,
+        config: LLMConfig = DEFAULT_LLM_CONFIG,
+    ) -> None:
+        BaseGameSummaryGenerator.__init__(
+            self,
+            gemini_api_key=gemini_api_key,
+            grok_api_key=grok_api_key,
+            config=config,
+        )
+
+
+class NBAFanRantSummarizer(FilePromptMixin, BaseGameSummaryGenerator):
+    """
+    Generates an angry hometown-fan NBA recap when the primary favorite team loses.
+
+    Expected ``data`` keys
+    ----------------------
+    - ``home_team``          str
+    - ``away_team``          str
+    - ``home_score``         int
+    - ``away_score``         int
+    - ``narrative_snippets`` str  — quarter-tagged play descriptions
+    - ``losing_team``        str  — full name of the featured team that lost
+    """
+
+    _PROMPT_FILE = Path("nba_game_fan_rant.txt")
+
+    def __init__(
+        self,
+        gemini_api_key: Optional[str] = None,
+        grok_api_key: Optional[str] = None,
+        config: LLMConfig = DEFAULT_LLM_CONFIG,
+    ) -> None:
+        BaseGameSummaryGenerator.__init__(
+            self,
+            gemini_api_key=gemini_api_key,
+            grok_api_key=grok_api_key,
+            config=config,
+        )

--- a/src/screamsheet/providers/extractors.py
+++ b/src/screamsheet/providers/extractors.py
@@ -3,11 +3,16 @@
 These classes own the data-fetching and transformation steps only — no LLM logic lives here.
 Pass the returned ExtractedInfo dict to the appropriate summarizer in llm/summary.py.
 """
+import logging
+import re
+import time
 import requests
 from typing import Optional, Dict, Any, Union, List
 
 from ..db import lookup_player as _db_lookup_player
 from ..db.nhl_teams_db import lookup_team_by_id as _db_lookup_team
+
+logger = logging.getLogger(__name__)
 
 ExtractedInfo = Dict[str, Union[str, int]]
 
@@ -230,3 +235,241 @@ class NHLGameExtractor:
         except (KeyError, IndexError, TypeError) as e:
             print(f"Error parsing NHL game data: {e}")
             return "Could not parse NHL game details for summary generation."
+
+
+class NBAGameExtractor:
+    """Fetches and extracts NBA game data from nba_api for LLM summarizers.
+
+    Play-by-play is sourced from ``PlayByPlayV3`` (preferred — works for
+    playoff games) with ``PlayByPlayV2`` as a fallback.  Final score and team
+    names are authoritative from ``BoxScoreTraditionalV2``.
+    """
+
+    # V3 actionType strings we include in the narrative
+    _V3_NARRATIVE_TYPES = {"Made Shot", "Free Throw", "Turnover", "Foul"}
+
+    # V2 EVENTMSGTYPE codes we include in the narrative
+    _V2_MADE_SHOT = 1
+    _V2_FREE_THROW = 3
+    _V2_TURNOVER = 5
+    _V2_FOUL = 6
+    _V2_NARRATIVE_CODES = {_V2_MADE_SHOT, _V2_FREE_THROW, _V2_TURNOVER, _V2_FOUL}
+
+    @staticmethod
+    def _parse_v3_clock(clock: str) -> str:
+        """Convert ISO 8601 duration ``PT11M30.00S`` → ``11:30``."""
+        m = re.match(r"PT(\d+)M([\d.]+)S", clock)
+        if m:
+            mins = m.group(1)
+            secs = str(int(float(m.group(2)))).zfill(2)
+            return f"{mins}:{secs}"
+        return clock
+
+    def fetch_raw_data(self, game_id: str) -> Optional[Dict[str, Any]]:
+        """Return a dict with ``play_by_play`` DataFrame, ``boxscore`` DataFrame,
+        and ``pbp_version`` (3, 2, or 0).
+
+        Strategy:
+        1. Fetch BoxScoreTraditionalV2 (always reliable).
+        2. Try PlayByPlayV3 first — handles regular-season *and* playoff games.
+        3. Fall back to PlayByPlayV2 if V3 fails.
+        4. If both fail, return an empty DataFrame (box-score-only summary).
+        """
+        import pandas as pd
+
+        try:
+            from nba_api.stats.endpoints import boxscoretraditionalv2
+        except ImportError:
+            logger.error("nba_api not installed — cannot fetch NBA game data")
+            return None
+
+        # ---- boxscore (required) ----
+        try:
+            box_df = boxscoretraditionalv2.BoxScoreTraditionalV2(
+                game_id=game_id
+            ).get_data_frames()[0]
+        except Exception:
+            logger.exception("BoxScoreTraditionalV2 failed for game_id=%s", game_id)
+            return None
+
+        # nba_api enforces a ~600 ms rate limit between consecutive requests.
+        time.sleep(0.8)
+
+        # ---- play-by-play V3 (preferred — works for playoffs) ----
+        try:
+            from nba_api.stats.endpoints import playbyplayv3
+            pbp_df = playbyplayv3.PlayByPlayV3(
+                game_id=game_id, start_period=0, end_period=14
+            ).get_data_frames()[0]
+            logger.info("PlayByPlayV3: %d events for game_id=%s", len(pbp_df), game_id)
+            return {"play_by_play": pbp_df, "boxscore": box_df, "pbp_version": 3}
+        except Exception:
+            logger.warning(
+                "PlayByPlayV3 failed for game_id=%s — trying V2", game_id, exc_info=True
+            )
+
+        time.sleep(0.8)
+
+        # ---- play-by-play V2 (fallback — regular season only) ----
+        try:
+            from nba_api.stats.endpoints import playbyplayv2
+            pbp_df = playbyplayv2.PlayByPlayV2(game_id=game_id).get_data_frames()[0]
+            logger.info("PlayByPlayV2: %d events for game_id=%s", len(pbp_df), game_id)
+            return {"play_by_play": pbp_df, "boxscore": box_df, "pbp_version": 2}
+        except Exception:
+            logger.warning(
+                "PlayByPlayV2 also failed for game_id=%s — summary will be box-score only",
+                game_id,
+                exc_info=True,
+            )
+
+        return {"play_by_play": pd.DataFrame(), "boxscore": box_df, "pbp_version": 0}
+
+    def extract_key_info(
+        self,
+        raw_data: Optional[Dict[str, Any]],
+        featured_team_id: int,
+    ) -> Union[ExtractedInfo, str]:
+        """Extract team names, final score, and play-by-play narrative.
+
+        Handles V3 columns (``scoreHome``/``scoreAway``, ``actionType``,
+        ``description``), V2 columns (``SCORE``, ``EVENTMSGTYPE``,
+        ``HOMEDESCRIPTION``/``VISITORDESCRIPTION``), and an empty play-by-play
+        DataFrame (box-score-only fallback for both score and narrative).
+        """
+        if not raw_data:
+            return "No game data available."
+
+        try:
+            import pandas as pd
+
+            pbp: pd.DataFrame = raw_data["play_by_play"]
+            box: pd.DataFrame = raw_data["boxscore"]
+            pbp_version: int = raw_data.get("pbp_version", 0)
+
+            # ---- team IDs and names from boxscore ----
+            team_ids = box["TEAM_ID"].unique()
+            if len(team_ids) < 2:
+                return "Could not identify teams in NBA boxscore."
+
+            # Default order from boxscore (may be visitor-first; corrected below)
+            home_team_id: int = int(team_ids[0])
+            away_team_id: int = int(team_ids[1])
+
+            # V3 play-by-play has a `location` column: 'h' = home, 'v' = visitor.
+            # Use it to reliably map team_id → home/away.
+            if pbp_version == 3 and not pbp.empty and "location" in pbp.columns and "teamId" in pbp.columns:
+                home_rows_pbp = pbp[(pbp["location"] == "h") & pbp["teamId"].notna()]
+                away_rows_pbp = pbp[(pbp["location"] == "v") & pbp["teamId"].notna()]
+                if not home_rows_pbp.empty and not away_rows_pbp.empty:
+                    home_team_id = int(home_rows_pbp.iloc[0]["teamId"])
+                    away_team_id = int(away_rows_pbp.iloc[0]["teamId"])
+                    logger.debug(
+                        "V3 location: home_team_id=%s away_team_id=%s", home_team_id, away_team_id
+                    )
+
+            def _team_name(tid: int) -> str:
+                rows = box[box["TEAM_ID"] == tid]
+                if rows.empty:
+                    return "Unknown Team"
+                r = rows.iloc[0]
+                city = str(r.get("TEAM_CITY", ""))
+                name = str(r.get("TEAM_NICKNAME", r.get("TEAM_NAME", "")))
+                return f"{city} {name}".strip()
+
+            home_team_name = _team_name(home_team_id)
+            away_team_name = _team_name(away_team_id)
+            featured_team_is_home = (featured_team_id == home_team_id)
+
+            # ---- final score ----
+            home_score: int
+            away_score: int
+
+            if pbp_version == 3 and not pbp.empty and "scoreHome" in pbp.columns:
+                # V3: scoreHome/scoreAway columns, empty string on non-scoring rows
+                valid = pbp[pbp["scoreHome"].notna() & (pbp["scoreHome"] != "")]
+                if not valid.empty:
+                    last = valid.iloc[-1]
+                    home_score = int(float(str(last["scoreHome"])))
+                    away_score = int(float(str(last["scoreAway"])))
+                else:
+                    home_score = int(box[box["TEAM_ID"] == home_team_id]["PTS"].sum())
+                    away_score = int(box[box["TEAM_ID"] == away_team_id]["PTS"].sum())
+            elif pbp_version == 2 and not pbp.empty and "SCORE" in pbp.columns:
+                # V2: "VISITOR - HOME" string in SCORE column
+                score_rows = pbp[pbp["SCORE"].notna() & (pbp["SCORE"] != "")]
+                if not score_rows.empty:
+                    parts = str(score_rows.iloc[-1]["SCORE"]).split(" - ")
+                    away_score = int(parts[0].strip()) if len(parts) == 2 else 0
+                    home_score = int(parts[1].strip()) if len(parts) == 2 else 0
+                else:
+                    home_score = int(box[box["TEAM_ID"] == home_team_id]["PTS"].sum())
+                    away_score = int(box[box["TEAM_ID"] == away_team_id]["PTS"].sum())
+            else:
+                # No play-by-play — use boxscore totals
+                home_score = int(box[box["TEAM_ID"] == home_team_id]["PTS"].sum())
+                away_score = int(box[box["TEAM_ID"] == away_team_id]["PTS"].sum())
+
+            # ---- narrative ----
+            narrative_parts: List[str] = []
+
+            if pbp_version == 3 and not pbp.empty and "actionType" in pbp.columns:
+                for _, row in pbp.iterrows():
+                    if str(row.get("actionType", "")) not in self._V3_NARRATIVE_TYPES:
+                        continue
+                    desc = str(row.get("description", "")).strip()
+                    if not desc or desc.lower() == "nan":
+                        continue
+                    period = row.get("period", "")
+                    clock = self._parse_v3_clock(str(row.get("clock", "")).strip())
+                    prefix = f"[Q{period} {clock}]" if period and clock else ""
+                    narrative_parts.append(f"{prefix} {desc}".strip())
+
+            elif pbp_version == 2 and not pbp.empty and "EVENTMSGTYPE" in pbp.columns:
+                for _, row in pbp.iterrows():
+                    if row.get("EVENTMSGTYPE") not in self._V2_NARRATIVE_CODES:
+                        continue
+                    home_desc = str(row.get("HOMEDESCRIPTION") or "").strip()
+                    visit_desc = str(row.get("VISITORDESCRIPTION") or "").strip()
+                    desc = home_desc or visit_desc
+                    if not desc or desc.lower() == "nan":
+                        continue
+                    period = row.get("PERIOD", "")
+                    clock = str(row.get("PCTIMESTRING") or "").strip()
+                    prefix = f"[Q{period} {clock}]" if period and clock else ""
+                    narrative_parts.append(f"{prefix} {desc}".strip())
+
+            # If no play-by-play at all, build a minimal narrative from the top
+            # scorers in the boxscore so the LLM has *something* to work with.
+            if not narrative_parts:
+                logger.info(
+                    "No play-by-play for game_id; building narrative from boxscore top scorers"
+                )
+                for tid, label in [(home_team_id, "Home"), (away_team_id, "Away")]:
+                    team_rows = box[box["TEAM_ID"] == tid].copy()
+                    team_rows = team_rows[team_rows["MIN"].notna() & (team_rows["MIN"] != "")]
+                    top = team_rows.nlargest(3, "PTS") if "PTS" in team_rows.columns else team_rows.head(3)
+                    for _, r in top.iterrows():
+                        name = str(r.get("PLAYER_NAME", "Unknown"))
+                        pts = int(float(str(r.get("PTS", 0)))) if str(r.get("PTS", "nan")) != "nan" else 0
+                        reb = int(float(str(r.get("REB", 0)))) if str(r.get("REB", "nan")) != "nan" else 0
+                        ast = int(float(str(r.get("AST", 0)))) if str(r.get("AST", "nan")) != "nan" else 0
+                        narrative_parts.append(
+                            f"{name} ({label}): {pts} pts, {reb} reb, {ast} ast"
+                        )
+
+            losing_team = home_team_name if home_score < away_score else away_team_name
+
+            return {
+                "home_team": home_team_name,
+                "away_team": away_team_name,
+                "home_score": home_score,
+                "away_score": away_score,
+                "featured_team_is_home": featured_team_is_home,
+                "losing_team": losing_team,
+                "narrative_snippets": " ".join(narrative_parts),
+            }
+
+        except (KeyError, IndexError, TypeError, ValueError) as e:
+            logger.exception("Error parsing NBA game data")
+            return "Could not parse NBA game details for summary generation."

--- a/src/screamsheet/providers/nba_provider.py
+++ b/src/screamsheet/providers/nba_provider.py
@@ -1,140 +1,321 @@
 """NBA data provider for fetching NBA game data."""
-import requests
+import logging
+import math
 import pandas as pd
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any, Optional, List, Dict
 
 from ..base import DataProvider
 
+logger = logging.getLogger(__name__)
+
 try:
-    from nba_api.stats.endpoints import leaguegamefinder, leaguestandings
-    from nba_api.stats.static import teams
+    from nba_api.stats.endpoints import leaguegamefinder, leaguestandings, boxscoretraditionalv2
 except ImportError:
-    print("Warning: nba_api package not installed. NBA provider will have limited functionality.")
+    logger.warning("nba_api package not installed — NBA provider will have limited functionality.")
 
 
 class NBADataProvider(DataProvider):
     """
     Data provider for NBA using the nba_api package.
-    
+
     Provides access to:
     - Game scores
     - League standings
-    
-    Note: Box scores and game summaries not yet fully implemented for NBA.
+    - Box scores
+    - Game summaries (via LLM)
     """
-    
-    def __init__(self, **config):
+
+    def __init__(self, **config: Any) -> None:
         super().__init__(**config)
+        # Cache game_id lookups to avoid redundant API calls within one run.
+        # Key: (team_id, date_str)  Value: game_id or None
+        self._game_id_cache: Dict[tuple, Optional[str]] = {}
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _safe_int(value: Any, default: int = 0) -> int:
+        """Convert *value* to int, returning *default* for NaN/None/non-numeric."""
+        try:
+            if value is None:
+                return default
+            f = float(value)
+            return default if math.isnan(f) else int(f)
+        except (TypeError, ValueError):
+            return default
+
+    def _get_game_id(self, team_id: int, date: datetime) -> Optional[str]:
+        """Return the GAME_ID for *team_id* on *date*, or None if not found.
+
+        Results are cached per (team_id, date) pair so repeated calls within
+        the same run do not trigger extra API requests.
+        """
+        date_str = date.strftime("%Y-%m-%d")
+        cache_key = (team_id, date_str)
+        if cache_key in self._game_id_cache:
+            logger.debug("game_id cache hit for team %s on %s", team_id, date_str)
+            return self._game_id_cache[cache_key]
+
+        logger.info("Looking up game_id for team_id=%s on %s", team_id, date_str)
+        try:
+            finder = leaguegamefinder.LeagueGameFinder(
+                team_id_nullable=team_id,
+                date_from_nullable=date_str,
+                date_to_nullable=date_str,
+            )
+            df = finder.get_data_frames()[0]
+            if df.empty:
+                logger.warning("No game found for team_id=%s on %s", team_id, date_str)
+                self._game_id_cache[cache_key] = None
+                return None
+            game_id = str(df.iloc[0]["GAME_ID"])
+            logger.info("Found game_id=%s for team_id=%s on %s", game_id, team_id, date_str)
+            self._game_id_cache[cache_key] = game_id
+            return game_id
+        except Exception:
+            logger.exception("Error looking up game_id for team_id=%s on %s", team_id, date_str)
+            self._game_id_cache[cache_key] = None
+            return None
     
-    def get_game_scores(self, date: datetime) -> list:
+    # ------------------------------------------------------------------
+    # DataProvider interface
+    # ------------------------------------------------------------------
+
+    def get_game_scores(self, date: datetime) -> List[Dict[str, Any]]:
         """
         Get NBA game scores for a specific date.
-        
-        Args:
-            date: The date to fetch scores for
-            
-        Returns:
-            List of game score dictionaries
+
+        Uses the MATCHUP column to determine home vs. away:
+        - ``"PHI vs. BOS"`` → Philadelphia is home
+        - ``"BOS @ PHI"``   → Boston is away
         """
+        date_str = date.strftime("%Y-%m-%d")
         try:
-            # Use nba_api to get games for the date
-            date_str = date.strftime("%Y-%m-%d")
-            
-            # Get all games from league game finder
-            gamefinder = leaguegamefinder.LeagueGameFinder(
+            finder = leaguegamefinder.LeagueGameFinder(
                 date_from_nullable=date_str,
-                date_to_nullable=date_str
+                date_to_nullable=date_str,
             )
-            games_df = gamefinder.get_data_frames()[0]
-            
+            games_df = finder.get_data_frames()[0]
+
             if games_df.empty:
                 return []
-            
-            # Process games - note that each game appears twice (once for each team)
-            games = []
-            seen_game_ids = set()
-            
+
+            games: List[Dict[str, Any]] = []
+            seen_game_ids: set = set()
+
             for _, row in games_df.iterrows():
-                game_id = row['GAME_ID']
+                game_id = row["GAME_ID"]
                 if game_id in seen_game_ids:
                     continue
                 seen_game_ids.add(game_id)
-                
-                # Get both teams' data for this game
-                game_data = games_df[games_df['GAME_ID'] == game_id]
-                
-                if len(game_data) >= 2:
-                    teams_data = game_data.iloc[:2]
-                    
-                    game_info = {
-                        "gameDate": row['GAME_DATE'],
-                        "away_team": teams_data.iloc[1]['TEAM_NAME'],
-                        "home_team": teams_data.iloc[0]['TEAM_NAME'],
-                        "away_score": int(teams_data.iloc[1]['PTS']),
-                        "home_score": int(teams_data.iloc[0]['PTS']),
-                        "status": "Final"
-                    }
-                    games.append(game_info)
-            
+
+                game_rows = games_df[games_df["GAME_ID"] == game_id]
+                if len(game_rows) < 2:
+                    continue
+
+                # Identify home / away by MATCHUP content
+                home_rows = game_rows[game_rows["MATCHUP"].str.contains(r"\bvs\.", regex=True)]
+                away_rows = game_rows[game_rows["MATCHUP"].str.contains(r"\s@\s", regex=True)]
+
+                if home_rows.empty or away_rows.empty:
+                    # Fallback: row 0 home, row 1 away
+                    home_row = game_rows.iloc[0]
+                    away_row = game_rows.iloc[1]
+                else:
+                    home_row = home_rows.iloc[0]
+                    away_row = away_rows.iloc[0]
+
+                games.append({
+                    "gameDate": str(home_row["GAME_DATE"]),
+                    "home_team": str(home_row["TEAM_NAME"]),
+                    "away_team": str(away_row["TEAM_NAME"]),
+                    "home_score": int(home_row["PTS"]),
+                    "away_score": int(away_row["PTS"]),
+                    "status": "Final",
+                })
+
+            logger.info("Fetched %d NBA game(s) for %s", len(games), date_str)
             return games
-        except Exception as e:
-            print(f"Error getting NBA game scores: {e}")
+        except Exception:
+            logger.exception("Error fetching NBA game scores for %s", date_str)
             return []
     
     def get_standings(self) -> pd.DataFrame:
         """
         Get current NBA league standings.
-        
+
         Returns:
-            DataFrame with standings data
+            DataFrame with columns: conference, team, wins, losses, pct,
+            conf_record, division_rank — sorted by conference then win pct desc.
         """
         try:
             standings = leaguestandings.LeagueStandings()
-            standings_df = standings.get_data_frames()[0]
-            
-            # Simplify to key columns
-            if not standings_df.empty:
-                standings_df = standings_df[[
-                    'Conference',
-                    'TeamCity',
-                    'TeamName',
-                    'WINS',
-                    'LOSSES',
-                    'WinPCT',
-                    'ConferenceRecord',
-                    'DivisionRank'
-                ]].copy()
-                
-                # Combine city and team name for full team name
-                standings_df['FullTeamName'] = standings_df['TeamCity'] + ' ' + standings_df['TeamName']
-                
-                standings_df = standings_df[[
-                    'Conference',
-                    'FullTeamName',
-                    'WINS',
-                    'LOSSES',
-                    'WinPCT',
-                    'ConferenceRecord',
-                    'DivisionRank'
-                ]].copy()
-                
-                standings_df.columns = [
-                    'conference',
-                    'team',
-                    'wins',
-                    'losses',
-                    'pct',
-                    'conf_record',
-                    'division_rank'
-                ]
-                
-                return standings_df.sort_values(
-                    by=['conference', 'pct'],
-                    ascending=[True, False]
-                ).reset_index(drop=True)
-            
+            df = standings.get_data_frames()[0]
+
+            if df.empty:
+                return pd.DataFrame()
+
+            df = df[[
+                "Conference",
+                "TeamCity",
+                "TeamName",
+                "WINS",
+                "LOSSES",
+                "WinPCT",
+                "ConferenceRecord",
+                "DivisionRank",
+            ]].copy()
+
+            df["FullTeamName"] = df["TeamCity"] + " " + df["TeamName"]
+            df = df[[
+                "Conference",
+                "FullTeamName",
+                "WINS",
+                "LOSSES",
+                "WinPCT",
+                "ConferenceRecord",
+                "DivisionRank",
+            ]].copy()
+            df.columns = [
+                "conference", "team", "wins", "losses",
+                "pct", "conf_record", "division_rank",
+            ]
+
+            return df.sort_values(
+                by=["conference", "pct"],
+                ascending=[True, False],
+            ).reset_index(drop=True)
+
+        except Exception:
+            logger.exception("Error fetching NBA standings")
             return pd.DataFrame()
-        except Exception as e:
-            print(f"Error getting NBA standings: {e}")
-            return pd.DataFrame()
+
+    def has_game(self, team_id: int, date: datetime) -> bool:
+        """Return True if *team_id* played on *date*."""
+        result = self._get_game_id(team_id, date) is not None
+        logger.info("has_game(team_id=%s, date=%s) -> %s", team_id, date.strftime("%Y-%m-%d"), result)
+        return result
+
+    def get_box_score(self, team_id: int, date: datetime) -> Optional[Dict[str, Any]]:
+        """
+        Get box score for *team_id* on *date*.
+
+        Returns a dict with key ``player_stats``: a list of per-player dicts with
+        keys: name, MIN, FG, 3P, FT, REB, AST, STL, BLK, PTS.
+        Returns None if the team did not play or data is unavailable.
+        """
+        game_id = self._get_game_id(team_id, date)
+        if not game_id:
+            return None
+
+        try:
+            box = boxscoretraditionalv2.BoxScoreTraditionalV2(game_id=game_id)
+            df = box.get_data_frames()[0]  # PlayerStats DataFrame
+
+            team_df = df[df["TEAM_ID"] == team_id].copy()
+            if team_df.empty:
+                logger.warning("BoxScore returned no rows for team_id=%s game_id=%s", team_id, game_id)
+                return None
+
+            # Drop rows where the player did not play (MIN is NaN)
+            team_df = team_df[team_df["MIN"].notna() & (team_df["MIN"] != "")]
+            logger.debug("Box score rows after DNP filter: %d", len(team_df))
+
+            si = self._safe_int  # shorthand
+            player_stats: List[Dict[str, Any]] = []
+            for _, row in team_df.iterrows():
+                fg = f"{si(row.get('FGM'))}-{si(row.get('FGA'))}"
+                three_p = f"{si(row.get('FG3M'))}-{si(row.get('FG3A'))}"
+                ft = f"{si(row.get('FTM'))}-{si(row.get('FTA'))}"
+
+                raw_min = str(row.get("MIN", "0:00"))
+                min_str = raw_min.split(".")[0] if "." in raw_min else raw_min
+
+                player_stats.append({
+                    "name": str(row["PLAYER_NAME"]),
+                    "MIN": min_str,
+                    "FG": fg,
+                    "3P": three_p,
+                    "FT": ft,
+                    "REB": si(row.get("REB")),
+                    "AST": si(row.get("AST")),
+                    "STL": si(row.get("STL")),
+                    "BLK": si(row.get("BLK")),
+                    "PTS": si(row.get("PTS")),
+                })
+
+            # Sort by points descending so leading scorers appear first
+            player_stats.sort(key=lambda p: p["PTS"], reverse=True)
+            logger.info("Box score for game_id=%s: %d players", game_id, len(player_stats))
+            return {"player_stats": player_stats}
+
+        except Exception:
+            logger.exception("Error fetching NBA box score for team_id=%s game_id=%s", team_id, game_id)
+            return None
+
+    def get_game_summary(
+        self,
+        team_id: int,
+        date: datetime,
+        is_primary_favorite: bool = False,
+    ) -> Optional[str]:
+        """
+        Generate an LLM game summary for *team_id* on *date*.
+
+        Uses the angry fan-rant persona when ``is_primary_favorite`` is True
+        and the featured team lost; otherwise uses the neutral recap.
+        """
+        import os
+        from .extractors import NBAGameExtractor
+        from ..llm.summarizers import NBAGameSummarizer, NBAFanRantSummarizer
+
+        game_id = self._get_game_id(team_id, date)
+        if not game_id:
+            return None
+
+        try:
+            extractor = NBAGameExtractor()
+            raw = extractor.fetch_raw_data(game_id)
+            extracted = extractor.extract_key_info(raw, team_id)
+            if isinstance(extracted, str):
+                return extracted
+
+            use_rant = False
+            if is_primary_favorite:
+                home_score = int(extracted["home_score"])
+                away_score = int(extracted["away_score"])
+                is_home = bool(extracted.get("featured_team_is_home", False))
+                team_won = home_score > away_score if is_home else away_score > home_score
+                use_rant = not team_won
+                result_str = "won" if team_won else "lost"
+                logger.info(
+                    "Game summary: team_id=%s %s (%s-%s) — using %s",
+                    team_id, result_str, extracted["home_score"], extracted["away_score"],
+                    "FanRantSummarizer" if use_rant else "GameSummarizer",
+                )
+            else:
+                logger.info("Game summary: team_id=%s (not primary favorite) — using GameSummarizer", team_id)
+
+            gemini_key = os.environ.get("GEMINI_API_KEY")
+            grok_key = os.environ.get("GROK_API_KEY")
+
+            summarizer: "NBAGameSummarizer | NBAFanRantSummarizer"
+            if use_rant:
+                summarizer = NBAFanRantSummarizer(
+                    gemini_api_key=gemini_key,
+                    grok_api_key=grok_key,
+                )
+            else:
+                summarizer = NBAGameSummarizer(
+                    gemini_api_key=gemini_key,
+                    grok_api_key=grok_key,
+                )
+
+            return summarizer.generate_summary(data=extracted)
+
+        except Exception:
+            logger.exception("Error generating NBA game summary for team_id=%s game_id=%s", team_id, game_id)
+            return None

--- a/src/screamsheet/renderers/box_score.py
+++ b/src/screamsheet/renderers/box_score.py
@@ -1,13 +1,16 @@
 """Box score section renderer."""
+import logging
 from datetime import datetime
 from typing import List, Any, Optional
-from reportlab.platypus import Table, TableStyle, Spacer, Paragraph
+from reportlab.platypus import Table, TableStyle, Spacer, Paragraph, PageBreak
 from reportlab.platypus.flowables import KeepInFrame
 from reportlab.lib import colors
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.enums import TA_CENTER, TA_LEFT
 
 from ..base import Section, DataProvider
+
+logger = logging.getLogger(__name__)
 
 
 class BoxScoreSection(Section):
@@ -56,7 +59,10 @@ class BoxScoreSection(Section):
     
     def fetch_data(self):
         """Fetch box score from the provider."""
+        logger.info("Fetching box score for team_id=%s date=%s", self.team_id, self.date.strftime("%Y-%m-%d"))
         self.data = self.provider.get_box_score(self.team_id, self.date)
+        if self.data is None:
+            logger.warning("get_box_score returned None for team_id=%s date=%s — back page may be blank", self.team_id, self.date.strftime("%Y-%m-%d"))
     
     def render(self) -> List[Any]:
         """Render the box score section with two-column layout."""
@@ -64,9 +70,10 @@ class BoxScoreSection(Section):
             self.fetch_data()
         
         if not self.data:
+            logger.warning("No box score data for team_id=%s — returning empty render", self.team_id)
             return []
         
-        elements = []
+        elements: List[Any] = [PageBreak()]
         
         # Get game summary from provider
         game_summary = self.provider.get_game_summary(
@@ -94,6 +101,9 @@ class BoxScoreSection(Section):
             elif 'home_skaters' in self.data:
                 # NHL box score (raw data - legacy format)
                 right_column.extend(self._render_nhl_boxscore(self.data))
+            elif 'player_stats' in self.data:
+                # NBA box score
+                right_column.extend(self._render_nba_boxscore(self.data))
         
         # Wrap the summary in KeepInFrame so it never exceeds the page frame
         # height (708pt on 'Later' pages with letter/36pt-margin layout).
@@ -270,4 +280,66 @@ class BoxScoreSection(Section):
         for item in legend_items:
             elements.append(Paragraph(item, self.legend_style))
         
+        return elements
+
+    def _render_nba_boxscore(self, boxscore_data: dict) -> List[Any]:
+        """Render NBA box score with per-player stats and an acronym legend."""
+        elements: List[Any] = []
+
+        player_stats = boxscore_data.get("player_stats", [])
+        if not player_stats:
+            return elements
+
+        # Drop the first name, keep everything else ("Wendell Carter Jr." → "Carter Jr.")
+        def _short_name(full: str) -> str:
+            parts = full.split()
+            return " ".join(parts[1:]) if len(parts) > 1 else full
+
+        header = ["Player", "MIN", "FG", "3P", "FT", "REB", "AST", "PTS"]
+        table_data = [header]
+        for p in player_stats:
+            table_data.append([
+                _short_name(p.get("name", "")),
+                p.get("MIN", ""),
+                p.get("FG", ""),
+                p.get("3P", ""),
+                p.get("FT", ""),
+                str(p.get("REB", 0)),
+                str(p.get("AST", 0)),
+                str(p.get("PTS", 0)),
+            ])
+
+        table_style = TableStyle([
+            ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+            ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
+            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+            ("FONTSIZE", (0, 0), (-1, -1), 7),
+            ("ALIGN", (0, 0), (0, -1), "LEFT"),
+            ("ALIGN", (1, 0), (-1, -1), "CENTER"),
+            ("LEFTPADDING", (0, 0), (-1, -1), 3),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 3),
+            ("TOPPADDING", (0, 0), (-1, -1), 2),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), 2),
+        ])
+
+        # Column widths: last name ~65pt, FG wider (e.g. "9-18"), counters narrow
+        # Total = 65+28+34+28+28+22+22+22 = 249pt — fits in a 270pt half-page column
+        col_widths = [65, 28, 34, 28, 28, 22, 22, 22]
+        nba_table = Table(table_data, colWidths=col_widths)
+        nba_table.setStyle(table_style)
+        elements.append(nba_table)
+        elements.append(Spacer(1, 8))
+
+        legend_items = [
+            "MIN = Minutes",
+            "FG = Field Goals (Made-Attempted)",
+            "3P = Three-Pointers (Made-Attempted)",
+            "FT = Free Throws (Made-Attempted)",
+            "REB = Rebounds",
+            "AST = Assists",
+            "PTS = Points",
+        ]
+        for item in legend_items:
+            elements.append(Paragraph(item, self.legend_style))
+
         return elements

--- a/src/screamsheet/sports/base_sports.py
+++ b/src/screamsheet/sports/base_sports.py
@@ -1,7 +1,10 @@
 """Base class for all sports screamsheets."""
+import logging
 from abc import abstractmethod
 from typing import List, Optional, Tuple
 from datetime import datetime
+
+logger = logging.getLogger(__name__)
 
 from ..base import BaseScreamsheet, Section, DataProvider
 from ..renderers import (
@@ -87,9 +90,15 @@ class SportsScreamsheet(BaseScreamsheet):
         Returns:
             (team_id, team_name) tuple, or None if no team played (or no list set).
         """
+        date_str = self.date.strftime("%Y-%m-%d")
+        logger.info("Resolving featured team for %s on %s (%d candidates)", self.sport_name, date_str, len(self.favorite_teams))
         for tid, tname in self.favorite_teams:
-            if self.provider.has_game(tid, self.date):
+            played = self.provider.has_game(tid, self.date)
+            logger.info("  %s (id=%s) played on %s: %s", tname, tid, date_str, played)
+            if played:
+                logger.info("Featured team selected: %s (id=%s)", tname, tid)
                 return (tid, tname)
+        logger.warning("No favorite team played on %s — back page will be skipped", date_str)
         return None
     
     def build_sections(self) -> List[Section]:

--- a/src/screamsheet/sports/nba.py
+++ b/src/screamsheet/sports/nba.py
@@ -15,6 +15,7 @@ class NBAScreamsheet(SportsScreamsheet):
         team_id: Optional[int] = None,
         team_name: Optional[str] = None,
         date: Optional[datetime] = None,
+        display_date: Optional[datetime] = None,
         favorite_teams: Optional[List[Tuple[int, str]]] = None,
     ):
         """
@@ -25,6 +26,7 @@ class NBAScreamsheet(SportsScreamsheet):
             team_id: NBA team ID (deprecated — use favorite_teams)
             team_name: Team name (deprecated — use favorite_teams)
             date: Target date (defaults to yesterday)
+            display_date: Date shown in the subtitle header (defaults to date)
             favorite_teams: Priority-ordered list of (team_id, team_name) tuples.
         """
         super().__init__(
@@ -33,6 +35,7 @@ class NBAScreamsheet(SportsScreamsheet):
             team_id=team_id,
             team_name=team_name,
             date=date,
+            display_date=display_date,
             favorite_teams=favorite_teams,
         )
     

--- a/tests/test_nba_provider.py
+++ b/tests/test_nba_provider.py
@@ -1,0 +1,285 @@
+"""Unit tests for NBADataProvider."""
+import pandas as pd
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from screamsheet.providers.nba_provider import NBADataProvider
+
+
+# ---------------------------------------------------------------------------
+# Helpers: fake DataFrames that mimic nba_api outputs
+# ---------------------------------------------------------------------------
+
+def _make_gamefinder_df(game_id: str, home_team: str, away_team: str,
+                        home_score: int, away_score: int,
+                        home_matchup: str, away_matchup: str) -> pd.DataFrame:
+    """Two-row DataFrame as returned by LeagueGameFinder (one row per team)."""
+    return pd.DataFrame([
+        {
+            "GAME_ID": game_id,
+            "TEAM_ID": 1610612755,
+            "TEAM_NAME": home_team,
+            "MATCHUP": home_matchup,   # e.g. "PHI vs. BOS" — home team
+            "PTS": home_score,
+            "GAME_DATE": "2026-05-03",
+        },
+        {
+            "GAME_ID": game_id,
+            "TEAM_ID": 1610612738,
+            "TEAM_NAME": away_team,
+            "MATCHUP": away_matchup,   # e.g. "BOS @ PHI" — away team
+            "PTS": away_score,
+            "GAME_DATE": "2026-05-03",
+        },
+    ])
+
+
+# ---------------------------------------------------------------------------
+# get_game_scores — home/away detection
+# ---------------------------------------------------------------------------
+
+class TestGetGameScoresHomeAway:
+    """Ensure MATCHUP column drives home/away assignment."""
+
+    def test_home_team_uses_vs_matchup(self):
+        """Team whose MATCHUP contains 'vs.' is the home team."""
+        df = _make_gamefinder_df(
+            game_id="0022500001",
+            home_team="Philadelphia 76ers",
+            away_team="Boston Celtics",
+            home_score=110,
+            away_score=105,
+            home_matchup="PHI vs. BOS",
+            away_matchup="BOS @ PHI",
+        )
+
+        with patch(
+            "screamsheet.providers.nba_provider.leaguegamefinder.LeagueGameFinder"
+        ) as mock_finder:
+            mock_finder.return_value.get_data_frames.return_value = [df]
+            provider = NBADataProvider()
+            scores = provider.get_game_scores(datetime(2026, 5, 3))
+
+        assert len(scores) == 1
+        game = scores[0]
+        assert game["home_team"] == "Philadelphia 76ers"
+        assert game["away_team"] == "Boston Celtics"
+        assert game["home_score"] == 110
+        assert game["away_score"] == 105
+
+    def test_away_team_uses_at_matchup(self):
+        """Team whose MATCHUP contains '@' is the away team."""
+        df = _make_gamefinder_df(
+            game_id="0022500002",
+            home_team="New York Knicks",
+            away_team="Milwaukee Bucks",
+            home_score=98,
+            away_score=101,
+            home_matchup="NYK vs. MIL",
+            away_matchup="MIL @ NYK",
+        )
+
+        with patch(
+            "screamsheet.providers.nba_provider.leaguegamefinder.LeagueGameFinder"
+        ) as mock_finder:
+            mock_finder.return_value.get_data_frames.return_value = [df]
+            provider = NBADataProvider()
+            scores = provider.get_game_scores(datetime(2026, 5, 3))
+
+        assert len(scores) == 1
+        assert scores[0]["home_team"] == "New York Knicks"
+        assert scores[0]["away_team"] == "Milwaukee Bucks"
+
+    def test_empty_result_returns_empty_list(self):
+        with patch(
+            "screamsheet.providers.nba_provider.leaguegamefinder.LeagueGameFinder"
+        ) as mock_finder:
+            mock_finder.return_value.get_data_frames.return_value = [pd.DataFrame()]
+            provider = NBADataProvider()
+            scores = provider.get_game_scores(datetime(2026, 5, 3))
+        assert scores == []
+
+
+# ---------------------------------------------------------------------------
+# has_game
+# ---------------------------------------------------------------------------
+
+class TestHasGame:
+    def test_returns_true_when_team_played(self):
+        df = pd.DataFrame([{
+            "GAME_ID": "0022500001",
+            "TEAM_ID": 1610612755,
+            "TEAM_NAME": "Philadelphia 76ers",
+            "MATCHUP": "PHI vs. BOS",
+            "PTS": 110,
+            "GAME_DATE": "2026-05-03",
+        }])
+        with patch(
+            "screamsheet.providers.nba_provider.leaguegamefinder.LeagueGameFinder"
+        ) as mock_finder:
+            mock_finder.return_value.get_data_frames.return_value = [df]
+            provider = NBADataProvider()
+            assert provider.has_game(1610612755, datetime(2026, 5, 3)) is True
+
+    def test_returns_false_when_team_did_not_play(self):
+        with patch(
+            "screamsheet.providers.nba_provider.leaguegamefinder.LeagueGameFinder"
+        ) as mock_finder:
+            mock_finder.return_value.get_data_frames.return_value = [pd.DataFrame()]
+            provider = NBADataProvider()
+            assert provider.has_game(1610612755, datetime(2026, 5, 3)) is False
+
+
+# ---------------------------------------------------------------------------
+# _get_game_id
+# ---------------------------------------------------------------------------
+
+class TestGetGameId:
+    def test_returns_game_id_when_found(self):
+        df = pd.DataFrame([{
+            "GAME_ID": "0022500001",
+            "TEAM_ID": 1610612755,
+            "TEAM_NAME": "Philadelphia 76ers",
+            "MATCHUP": "PHI vs. BOS",
+            "PTS": 110,
+            "GAME_DATE": "2026-05-03",
+        }])
+        with patch(
+            "screamsheet.providers.nba_provider.leaguegamefinder.LeagueGameFinder"
+        ) as mock_finder:
+            mock_finder.return_value.get_data_frames.return_value = [df]
+            provider = NBADataProvider()
+            game_id = provider._get_game_id(1610612755, datetime(2026, 5, 3))
+        assert game_id == "0022500001"
+
+    def test_returns_none_when_no_game(self):
+        with patch(
+            "screamsheet.providers.nba_provider.leaguegamefinder.LeagueGameFinder"
+        ) as mock_finder:
+            mock_finder.return_value.get_data_frames.return_value = [pd.DataFrame()]
+            provider = NBADataProvider()
+            game_id = provider._get_game_id(1610612755, datetime(2026, 5, 3))
+        assert game_id is None
+
+
+# ---------------------------------------------------------------------------
+# get_box_score
+# ---------------------------------------------------------------------------
+
+def _make_boxscore_df(team_id: int) -> pd.DataFrame:
+    return pd.DataFrame([
+        {
+            "TEAM_ID": team_id,
+            "PLAYER_NAME": "Joel Embiid",
+            "MIN": "32:41",
+            "FGM": 9, "FGA": 18,
+            "FG3M": 1, "FG3A": 3,
+            "FTM": 8, "FTA": 9,
+            "REB": 10, "AST": 3, "STL": 1, "BLK": 2, "PTS": 27,
+        },
+        {
+            "TEAM_ID": team_id,
+            "PLAYER_NAME": "Tyrese Maxey",
+            "MIN": "35:12",
+            "FGM": 7, "FGA": 14,
+            "FG3M": 3, "FG3A": 6,
+            "FTM": 4, "FTA": 4,
+            "REB": 4, "AST": 6, "STL": 2, "BLK": 0, "PTS": 21,
+        },
+    ])
+
+
+class TestGetBoxScore:
+    def test_returns_player_stats_dict(self):
+        team_id = 1610612755
+        finder_df = pd.DataFrame([{
+            "GAME_ID": "0022500001",
+            "TEAM_ID": team_id,
+            "TEAM_NAME": "Philadelphia 76ers",
+            "MATCHUP": "PHI vs. BOS",
+            "PTS": 110,
+            "GAME_DATE": "2026-05-03",
+        }])
+        box_df = _make_boxscore_df(team_id)
+
+        with patch(
+            "screamsheet.providers.nba_provider.leaguegamefinder.LeagueGameFinder"
+        ) as mock_finder, patch(
+            "screamsheet.providers.nba_provider.boxscoretraditionalv2.BoxScoreTraditionalV2"
+        ) as mock_box:
+            mock_finder.return_value.get_data_frames.return_value = [finder_df]
+            mock_box.return_value.get_data_frames.return_value = [box_df]
+
+            provider = NBADataProvider()
+            result = provider.get_box_score(team_id, datetime(2026, 5, 3))
+
+        assert result is not None
+        assert "player_stats" in result
+        assert len(result["player_stats"]) == 2
+        first = result["player_stats"][0]
+        assert first["name"] == "Joel Embiid"
+        assert first["PTS"] == 27
+        assert first["REB"] == 10
+        assert "FG" in first   # e.g. "9-18"
+
+    def test_returns_none_when_no_game(self):
+        with patch(
+            "screamsheet.providers.nba_provider.leaguegamefinder.LeagueGameFinder"
+        ) as mock_finder:
+            mock_finder.return_value.get_data_frames.return_value = [pd.DataFrame()]
+            provider = NBADataProvider()
+            result = provider.get_box_score(1610612755, datetime(2026, 5, 3))
+        assert result is None
+
+    def test_dnp_players_with_nan_stats_are_excluded(self):
+        """Players marked DNP have NaN stat values and must not crash get_box_score."""
+        import math
+        team_id = 1610612755
+        finder_df = pd.DataFrame([{
+            "GAME_ID": "0022500001",
+            "TEAM_ID": team_id,
+            "TEAM_NAME": "Philadelphia 76ers",
+            "MATCHUP": "PHI vs. BOS",
+            "PTS": 110,
+            "GAME_DATE": "2026-05-03",
+        }])
+        box_df = pd.DataFrame([
+            {
+                "TEAM_ID": team_id,
+                "PLAYER_NAME": "Joel Embiid",
+                "MIN": "32:41",
+                "FGM": 9, "FGA": 18,
+                "FG3M": 1, "FG3A": 3,
+                "FTM": 8, "FTA": 9,
+                "REB": 10, "AST": 3, "STL": 1, "BLK": 2, "PTS": 27,
+            },
+            {
+                "TEAM_ID": team_id,
+                "PLAYER_NAME": "Paul George",  # DNP
+                "MIN": float("nan"),
+                "FGM": float("nan"), "FGA": float("nan"),
+                "FG3M": float("nan"), "FG3A": float("nan"),
+                "FTM": float("nan"), "FTA": float("nan"),
+                "REB": float("nan"), "AST": float("nan"),
+                "STL": float("nan"), "BLK": float("nan"),
+                "PTS": float("nan"),
+            },
+        ])
+
+        with patch(
+            "screamsheet.providers.nba_provider.leaguegamefinder.LeagueGameFinder"
+        ) as mock_finder, patch(
+            "screamsheet.providers.nba_provider.boxscoretraditionalv2.BoxScoreTraditionalV2"
+        ) as mock_box:
+            mock_finder.return_value.get_data_frames.return_value = [finder_df]
+            mock_box.return_value.get_data_frames.return_value = [box_df]
+
+            provider = NBADataProvider()
+            result = provider.get_box_score(team_id, datetime(2026, 5, 3))
+
+        assert result is not None
+        names = [p["name"] for p in result["player_stats"]]
+        assert "Joel Embiid" in names
+        assert "Paul George" not in names, "DNP player with NaN MIN must be excluded"


### PR DESCRIPTION
…summary

Front page was already working (scores + standings). This commit delivers the full back page: box score, play-by-play LLM summary, and all the polish needed to make it print-ready.

Bug fixes
---------
- Fix missing back page: get_box_score() crashed with "cannot convert float NaN to integer" on DNP players whose stats are all NaN; add _safe_int() helper and filter rows where MIN is NaN before processing
- Fix wrong LLM persona: home/away team IDs were inverted because boxscore team_ids[0] is the visitor team; use PlayByPlayV3's location column ('h'/'v') to correctly assign home vs away, so a 76ers road win no longer triggers the fan-rant summarizer
- Fix "no game data" / KeyError 'resultSet': PlayByPlayV2 does not support playoff game IDs (prefix 004); switch to PlayByPlayV3 as primary source with V2 as fallback; if both fail, build narrative from top-3 boxscore scorers per team so the LLM always has input
- Fix IndentationError in box_score.py introduced by malformed edit to the _short_name helper

Play-by-play improvements
--------------------------
- Add _parse_v3_clock() to convert ISO 8601 "PT11M30.00S" → "11:30"
- Add 0.8 s sleep between nba_api requests to respect rate limit
- V3 actionType filter: "Made Shot", "Free Throw", "Turnover", "Foul"

Box score table
---------------
- Drop STL and BLK columns; keep MIN FG 3P FT REB AST PTS (7 cols)
- Display last name only: strip first name, keep remainder so "Wendell Carter Jr." → "Carter Jr." and "Joel Embiid" → "Embiid"
- Tighten column widths [65,28,34,28,28,22,22,22] = 249 pt total, fitting within the 270 pt right-hand column
- Legend: one definition per line, no pipe delimiters
- Add PageBreak() as first element so box score always starts on page 2

Logging
-------
- Add logging.basicConfig() to __main__.py so all module loggers produce visible output at runtime
- Add logger to nba_provider: info/warning at key decision points, exception() replacing all print(f"Error ...") calls
- Add logger to base_sports._resolve_featured_team(): logs each team checked, warns when no favorite team played
- Add logger to box_score.BoxScoreSection: warns when fetch_data() returns None and when render() returns empty

Infrastructure
--------------
- Cache _get_game_id() results on the provider instance to avoid three redundant API calls per run (has_game, get_box_score, get_game_summary all need the same game_id)
- Wire NBA to screamsheet.sh: add print_sheet call for ./Files/NBA_gamescores_${DATE}.pdf

Tests
-----
- New test: test_dnp_players_with_nan_stats_are_excluded