### PR TITLE
feat(order): define ScreamsheetOrder contract and run_order() entry p…

### DIFF
--- a/documentation/subscriber-setup/ISSUE_77_ORDER_CONTRACT.md
+++ b/documentation/subscriber-setup/ISSUE_77_ORDER_CONTRACT.md
@@ -1,0 +1,223 @@
+# Issue #77 — Define the ScreamsheetOrder Contract
+
+## Background
+
+The screamsheet system is being extended to support an **orchestration layer** — an external Python program that will call screamsheet repeatedly, each time with a different set of options (e.g., different subscribers, different favorite teams, different output locations).
+
+Currently, screamsheet reads its options exclusively from `config.yaml`. The orchestration layer cannot use that model because it needs to pass configuration in-memory at call time, without touching the filesystem.
+
+Screamsheet itself should remain unaware of the orchestration layer. Its job is to accept a well-defined input object, validate it, generate the requested sheets, and return a result.
+
+---
+
+## Goal
+
+Define a strict `ScreamsheetOrder` dataclass (or Pydantic model) that serves as the **only** public interface between any caller and the screamsheet engine. The contract lives inside the `screamsheet` package, and callers construct it themselves.
+
+---
+
+## The Contract
+
+A `ScreamsheetOrder` is a dictionary-like object whose **top-level keys determine which sheets are produced**. If a key is absent, that sheet is not generated — no key means no sheet, no exceptions.
+
+### Top-Level Keys
+
+| Key | Sheet produced | Value type |
+|---|---|---|
+| `nhl` | NHL Sports / Standings | `NHLOrderOptions` |
+| `mlb` | MLB Sports | `MLBOrderOptions` |
+| `nba` | NBA Sports | `NBAOrderOptions` |
+| `nfl` | NFL Sports | `NFLOrderOptions` |
+| `mlb_news` | MLB News | `MLBNewsOrderOptions` |
+| `mlb_trade_rumors` | MLB Trade Rumors | `MLBTradeRumorsOrderOptions` |
+| `presidential` | Presidential | `PresidentialOrderOptions` |
+| `sky` | Sky Tonight | `SkyOrderOptions` |
+| `output` | *(global)* | `OutputOrderOptions` — destination directory |
+
+All top-level keys are **optional**. An order with zero sport keys is valid (it simply generates nothing sport-related).
+
+### Per-Sheet Options
+
+Each options type mirrors the corresponding section of `config.yaml`. Initial field definitions:
+
+```python
+@dataclass
+class TeamEntry:
+    id: int
+    name: str
+
+@dataclass
+class NHLOrderOptions:
+    favorite_teams: list[TeamEntry]   # priority-ordered; used for game summary selection
+
+@dataclass
+class MLBOrderOptions:
+    favorite_teams: list[TeamEntry]
+    news_names: list[str]             # short names used to filter news/trade articles
+
+@dataclass
+class NBAOrderOptions:
+    favorite_teams: list[TeamEntry]
+
+@dataclass
+class NFLOrderOptions:
+    favorite_teams: list[TeamEntry]
+
+@dataclass
+class MLBNewsOrderOptions:
+    weather: WeatherLocationOptions | None = None
+
+@dataclass
+class MLBTradeRumorsOrderOptions:
+    weather: WeatherLocationOptions | None = None
+
+@dataclass
+class PresidentialOrderOptions:
+    weather: WeatherLocationOptions | None = None
+
+@dataclass
+class WeatherLocationOptions:
+    lat: float
+    lon: float
+    location_name: str
+
+@dataclass
+class SkyOrderOptions:
+    lat: float
+    lon: float
+    location_name: str
+
+@dataclass
+class OutputOrderOptions:
+    directory: str
+```
+
+### The Order Object
+
+`branding` is **not** part of the order — it is a screamsheet-internal setting read from `config.yaml` at generation time. The orchestration layer has no reason to control it.
+
+```python
+@dataclass
+class ScreamsheetOrder:
+    output: OutputOrderOptions | None = None
+    nhl: NHLOrderOptions | None = None
+    mlb: MLBOrderOptions | None = None
+    nba: NBAOrderOptions | None = None
+    nfl: NFLOrderOptions | None = None
+    mlb_news: MLBNewsOrderOptions | None = None
+    mlb_trade_rumors: MLBTradeRumorsOrderOptions | None = None
+    presidential: PresidentialOrderOptions | None = None
+    sky: SkyOrderOptions | None = None
+```
+
+---
+
+## Entry Point
+
+Add a public function `run_order(order: ScreamsheetOrder) -> str` that:
+
+1. Validates the order object.
+2. Iterates only the keys that are present (non-`None`).
+3. Generates each requested sheet.
+4. Copies output PDFs to `order.output.directory` if provided.
+5. Returns `"success"` on completion.
+
+The existing `uv run screamsheet` CLI path should be refactored to **construct a `ScreamsheetOrder` from `config.yaml`** and then call `run_order()` — so the new contract is the single path through the engine.
+
+---
+
+## Extensibility
+
+Adding a new sheet (e.g., `nhl_trade_rumors`) requires three steps:
+
+1. Define a new `NHLTradeRumorsOrderOptions` dataclass in `order.py`.
+2. Add `nhl_trade_rumors: NHLTradeRumorsOrderOptions | None = None` to `ScreamsheetOrder`.
+3. Register the sheet in the dispatch map inside `run_order()` (see below).
+
+Steps 1 and 2 are expected contract changes — they are intentional and auditable. Step 3 is the key to keeping `run_order()` itself closed to modification.
+
+### Use a Registry, Not an `if/elif` Chain
+
+If `run_order()` is written as a series of `if order.nhl: ... if order.mlb: ...` branches, every new sheet adds another branch and the function must be edited each time. Instead, maintain an internal dispatch registry:
+
+```python
+_REGISTRY: dict[str, Callable[[Any], None]] = {
+    "nhl":              _run_nhl,
+    "mlb":              _run_mlb,
+    "nba":              _run_nba,
+    "nfl":              _run_nfl,
+    "mlb_news":         _run_mlb_news,
+    "mlb_trade_rumors": _run_mlb_trade_rumors,
+    "presidential":     _run_presidential,
+    "sky":              _run_sky,
+}
+
+def run_order(order: ScreamsheetOrder) -> str:
+    for field in dataclasses.fields(order):
+        options = getattr(order, field.name)
+        if options is not None and field.name in _REGISTRY:
+            _REGISTRY[field.name](options)
+    return "success"
+```
+
+With this pattern, `run_order()` never changes. Adding a new sheet only touches `order.py` (new type + new field) and one new entry in `_REGISTRY`. The loop handles it automatically.
+
+### Summary
+
+| Concern | Assessment |
+|---|---|
+| Adding a new `*OrderOptions` type | Straightforward — isolated to `order.py` |
+| Adding a field to `ScreamsheetOrder` | Required but minimal; one line |
+| Updating `run_order()` dispatch | None needed with the registry pattern |
+| Callers (orchestration layer) | Only need to set the new field; everything else is unchanged |
+| `config.yaml` → order translation | One new key mapping; easy to add |
+
+The design scales well. The only thing to watch is keeping the `_REGISTRY` dict and the `ScreamsheetOrder` fields in sync — a missing registry entry for a present field must **never** silently no-op. `run_order()` should emit a `logging.warning` (or `logging.error`) when it encounters a non-`None` field with no registry entry, so the omission is immediately visible in logs without crashing the run.
+
+---
+
+## Test Harness
+
+Both are required.
+
+### Unit Test (CI gate)
+
+Write a unit test in `tests/` that:
+- Mocks the individual sheet generators so no API calls are made.
+- Constructs a `ScreamsheetOrder` with a subset of keys.
+- Calls `run_order()`.
+- Asserts only the expected sheets were generated (mock was called the right number of times).
+- Asserts missing keys produced no sheet.
+- Asserts an invalid order (e.g., `TeamEntry` with missing `id`) raises `ValidationError`.
+
+### Example Script (manual smoke-test)
+
+Add a small script at `examples/run_order_example.py` that:
+- Imports `screamsheet` as an external caller would.
+- Constructs a minimal `ScreamsheetOrder` (e.g., NHL only).
+- Calls `run_order()`.
+- Prints the result.
+
+Run with: `uv run python examples/run_order_example.py`
+
+This script serves as living documentation for the orchestration layer.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `ScreamsheetOrder` and all `*OrderOptions` types are defined in `src/screamsheet/order.py` with full type annotations.
+- [ ] `run_order(order: ScreamsheetOrder) -> str` is the single engine entry point; CLI path calls it.
+- [ ] A unit test passes showing a valid order with only `nhl` set produces exactly one NHL sheet and no others.
+- [ ] A unit test passes showing an order with no sport keys produces zero sheets and returns `"success"`.
+- [ ] A unit test passes showing an invalid order (malformed `TeamEntry`) raises `ValidationError`.
+- [ ] `examples/run_order_example.py` runs end-to-end with a real (or stubbed) NHL order.
+- [ ] `README.md` documents `run_order()` as the programmatic API.
+
+---
+
+## Out of Scope (follow-up issues)
+
+- Fallback behavior when no `favorite_teams` are set (e.g., pick a random team for the game summary).
+- Per-subscriber delivery (email, print queue routing).
+- Permutations of optional fields within each sheet's options.

--- a/examples/run_order_example.py
+++ b/examples/run_order_example.py
@@ -1,0 +1,32 @@
+"""Example: calling screamsheet from an external orchestration layer.
+
+This script simulates exactly what an orchestration layer would do:
+import screamsheet, construct a ScreamsheetOrder, call run_order().
+
+Run with:
+    uv run python examples/run_order_example.py
+"""
+from datetime import datetime
+
+import screamsheet
+from screamsheet.order import (
+    NHLOrderOptions,
+    OutputOrderOptions,
+    ScreamsheetOrder,
+    TeamEntry,
+)
+
+# Build a minimal order: NHL only, output to /tmp.
+order = ScreamsheetOrder(
+    output=OutputOrderOptions(directory="/tmp/screamsheet_example"),
+    nhl=NHLOrderOptions(
+        favorite_teams=[
+            TeamEntry(id=4, name="Philadelphia Flyers"),
+            TeamEntry(id=7, name="Buffalo Sabres"),
+        ]
+    ),
+)
+
+# run_order() generates only the sheets whose keys are set.
+result = screamsheet.run_order(order, today=datetime.now())
+print(f"Result: {result}")

--- a/src/screamsheet/__init__.py
+++ b/src/screamsheet/__init__.py
@@ -1,10 +1,14 @@
 """Modular screamsheet generation system."""
 from .factory import ScreamsheetFactory
+from .order import ScreamsheetOrder
+from .runner import run_order
 from .sports import MLBScreamsheet, NHLScreamsheet, NFLScreamsheet, NBAScreamsheet
 from .news import MLBTradeRumorsScreamsheet
 
 __all__ = [
     'ScreamsheetFactory',
+    'ScreamsheetOrder',
+    'run_order',
     'MLBScreamsheet',
     'NHLScreamsheet',
     'NFLScreamsheet',

--- a/src/screamsheet/__main__.py
+++ b/src/screamsheet/__main__.py
@@ -9,11 +9,24 @@ Usage:
 """
 import argparse
 import logging
-import shutil
 from datetime import datetime, timedelta
-from pathlib import Path
-from .factory import ScreamsheetFactory
 from .config import load_config
+from .factory import ScreamsheetFactory
+from .order import (
+    MLBNewsOrderOptions,
+    MLBOrderOptions,
+    MLBTradeRumorsOrderOptions,
+    NBAOrderOptions,
+    NHLOrderOptions,
+    OutputOrderOptions,
+    PersonOptions,
+    PresidentialOrderOptions,
+    ScreamsheetOrder,
+    SkyOrderOptions,
+    TeamEntry,
+    WeatherLocationOptions,
+)
+from .runner import _copy_to_output_dir, run_order
 from .sports import MLBScreamsheet, NHLScreamsheet, NFLScreamsheet, NBAScreamsheet
 from .news import MLBTradeRumorsScreamsheet, MLBNewsScreamsheet
 from .political import PresidentialScreamsheet
@@ -32,22 +45,6 @@ __all__ = [
 ]
 
 
-def _copy_to_output_dir(src: str, output_dir: str) -> None:
-    """Copy a generated PDF to the configured output directory.
-
-    No-ops silently when output_dir is empty.  Logs a warning if src is missing.
-    """
-    if not output_dir:
-        return
-    src_path = Path(src)
-    if not src_path.exists():
-        logging.getLogger(__name__).warning(
-            "Output copy skipped — file not found: %s", src
-        )
-        return
-    dest = Path(output_dir)
-    dest.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(src_path, dest / src_path.name)
 
 
 def _build_sheets(today_str: str) -> tuple[list, str]:
@@ -142,10 +139,73 @@ def _build_sheets(today_str: str) -> tuple[list, str]:
 
 
 def _run_sheet(label: str, factory_fn, output_dir: str) -> None:
+    _log = logging.getLogger(__name__)
     sheet = factory_fn()
     pdf_path = sheet.generate()
-    _copy_to_output_dir(pdf_path, output_dir)
-    print(f"Generated: {label}")
+    _log.info("Generated: %s", pdf_path)
+    if output_dir:
+        from pathlib import Path
+        dest = str(Path(output_dir) / Path(pdf_path).name)
+        _copy_to_output_dir(pdf_path, output_dir)
+        _log.info("Copied to: %s", dest)
+
+
+def _build_order_from_config(today: datetime) -> ScreamsheetOrder:
+    """Translate the on-disk config.yaml into a ScreamsheetOrder.
+
+    Produces an order that mirrors the full set of sheets currently generated
+    by the CLI, preserving existing behaviour exactly.
+    """
+    cfg = load_config()
+    weather_mlb = WeatherLocationOptions(
+        lat=cfg.weather.mlb_news.lat,
+        lon=cfg.weather.mlb_news.lon,
+        location_name=cfg.weather.mlb_news.location_name,
+    )
+    weather_presidential = WeatherLocationOptions(
+        lat=cfg.weather.presidential.lat,
+        lon=cfg.weather.presidential.lon,
+        location_name=cfg.weather.presidential.location_name,
+    )
+    return ScreamsheetOrder(
+        output=OutputOrderOptions(directory=cfg.output.directory),
+        nhl=NHLOrderOptions(
+            favorite_teams=[TeamEntry(id=t.id, name=t.name) for t in cfg.nhl.favorite_teams]
+        ),
+        mlb=MLBOrderOptions(
+            favorite_teams=[TeamEntry(id=t.id, name=t.name) for t in cfg.mlb.favorite_teams],
+            news_names=cfg.mlb.news_names,
+        ),
+        nba=NBAOrderOptions(
+            favorite_teams=[TeamEntry(id=t.id, name=t.name) for t in cfg.nba.favorite_teams]
+        ),
+        mlb_news=MLBNewsOrderOptions(
+            news_names=cfg.mlb.news_names,
+            weather=weather_mlb,
+        ),
+        mlb_trade_rumors=MLBTradeRumorsOrderOptions(
+            news_names=cfg.mlb.news_names,
+            weather=weather_mlb,
+        ),
+        presidential=PresidentialOrderOptions(weather=weather_presidential),
+        sky=SkyOrderOptions(
+            lat=cfg.sky.lat,
+            lon=cfg.sky.lon,
+            location_name=cfg.sky.location_name,
+            people=[
+                PersonOptions(
+                    name=p.name,
+                    birth_date=p.birth_date,
+                    birth_time=p.birth_time,
+                    birth_location=p.birth_location,
+                    sun_sign=p.sun_sign,
+                    moon_sign=p.moon_sign,
+                    ascendant=p.ascendant,
+                )
+                for p in cfg.sky.people
+            ],
+        ),
+    )
 
 
 def _pick_and_run(sheets: list, output_dir: str) -> None:
@@ -208,16 +268,18 @@ def main():
     else:
         today_str = datetime.now().strftime("%Y%m%d")
 
-    sheets, output_dir = _build_sheets(today_str)
-
-    if args.output_dir:
-        output_dir = args.output_dir
+    today = datetime.strptime(today_str, "%Y%m%d")
 
     if args.single:
+        sheets, output_dir = _build_sheets(today_str)
+        if args.output_dir:
+            output_dir = args.output_dir
         _pick_and_run(sheets, output_dir)
     else:
-        for label, factory_fn in sheets:
-            _run_sheet(label, factory_fn, output_dir)
+        order = _build_order_from_config(today)
+        if args.output_dir:
+            order.output = OutputOrderOptions(directory=args.output_dir)
+        run_order(order, today=today)
 
 
 if __name__ == "__main__":

--- a/src/screamsheet/order.py
+++ b/src/screamsheet/order.py
@@ -1,0 +1,142 @@
+"""ScreamsheetOrder contract — the public input model for the screamsheet engine.
+
+Each field on ScreamsheetOrder maps to one sheet type.  A field set to ``None``
+means "do not generate that sheet".  The presence of a non-None value is
+sufficient to trigger generation.
+
+Callers (including the CLI and external orchestration layers) construct a
+ScreamsheetOrder and pass it to ``runner.run_order()``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+class OrderValidationError(ValueError):
+    """Raised when a ScreamsheetOrder or any of its nested options are invalid."""
+
+
+@dataclass
+class TeamEntry:
+    """A single team with its provider ID and display name."""
+
+    id: int
+    name: str
+
+    def __post_init__(self) -> None:
+        if self.id <= 0:
+            raise OrderValidationError(
+                f"TeamEntry.id must be a positive integer, got {self.id!r}"
+            )
+        if not self.name:
+            raise OrderValidationError("TeamEntry.name must not be empty")
+
+
+@dataclass
+class WeatherLocationOptions:
+    """Lat/lon and display name for a weather location."""
+
+    lat: float
+    lon: float
+    location_name: str
+
+
+@dataclass
+class PersonOptions:
+    """Birth details for a horoscope reading (used by the Sky Tonight sheet)."""
+
+    name: str
+    birth_date: str       # YYYY-MM-DD
+    birth_time: str       # HH:MM (24-hour)
+    birth_location: str
+    sun_sign: str = ""
+    moon_sign: str = ""
+    ascendant: str = ""
+
+
+@dataclass
+class NHLOrderOptions:
+    """Options for the NHL sports / standings sheet."""
+
+    favorite_teams: list[TeamEntry] = field(default_factory=list)
+
+
+@dataclass
+class MLBOrderOptions:
+    """Options for the MLB sports sheet."""
+
+    favorite_teams: list[TeamEntry] = field(default_factory=list)
+    news_names: list[str] = field(default_factory=list)
+
+
+@dataclass
+class NBAOrderOptions:
+    """Options for the NBA sports sheet."""
+
+    favorite_teams: list[TeamEntry] = field(default_factory=list)
+
+
+@dataclass
+class NFLOrderOptions:
+    """Options for the NFL sports sheet."""
+
+    favorite_teams: list[TeamEntry] = field(default_factory=list)
+
+
+@dataclass
+class MLBNewsOrderOptions:
+    """Options for the MLB News sheet."""
+
+    news_names: list[str] = field(default_factory=list)
+    weather: WeatherLocationOptions | None = None
+
+
+@dataclass
+class MLBTradeRumorsOrderOptions:
+    """Options for the MLB Trade Rumors sheet."""
+
+    news_names: list[str] = field(default_factory=list)
+    weather: WeatherLocationOptions | None = None
+
+
+@dataclass
+class PresidentialOrderOptions:
+    """Options for the Presidential sheet."""
+
+    weather: WeatherLocationOptions | None = None
+
+
+@dataclass
+class SkyOrderOptions:
+    """Options for the Sky Tonight sheet."""
+
+    lat: float = 40.0
+    lon: float = -75.0
+    location_name: str = "My Location"
+    people: list[PersonOptions] = field(default_factory=list)
+
+
+@dataclass
+class OutputOrderOptions:
+    """Destination directory for generated PDFs."""
+
+    directory: str = ""
+
+
+@dataclass
+class ScreamsheetOrder:
+    """Complete input contract for the screamsheet engine.
+
+    Set a field to a non-None options object to include that sheet.
+    Leave a field as ``None`` to skip it entirely.
+    """
+
+    output: OutputOrderOptions | None = None
+    nhl: NHLOrderOptions | None = None
+    mlb: MLBOrderOptions | None = None
+    nba: NBAOrderOptions | None = None
+    nfl: NFLOrderOptions | None = None
+    mlb_news: MLBNewsOrderOptions | None = None
+    mlb_trade_rumors: MLBTradeRumorsOrderOptions | None = None
+    presidential: PresidentialOrderOptions | None = None
+    sky: SkyOrderOptions | None = None

--- a/src/screamsheet/runner.py
+++ b/src/screamsheet/runner.py
@@ -1,0 +1,224 @@
+"""run_order() — the single engine entry point for screamsheet generation.
+
+External callers (CLI, orchestration layers) construct a ScreamsheetOrder and
+call run_order().  The registry maps each order field name to a handler
+function; adding a new sheet type requires only a new field on ScreamsheetOrder
+and one new entry in _REGISTRY — this function never needs to change.
+"""
+from __future__ import annotations
+
+import dataclasses
+import logging
+import shutil
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Callable
+
+from .factory import ScreamsheetFactory
+from .order import (
+    MLBNewsOrderOptions,
+    MLBOrderOptions,
+    MLBTradeRumorsOrderOptions,
+    NBAOrderOptions,
+    NFLOrderOptions,
+    NHLOrderOptions,
+    PresidentialOrderOptions,
+    ScreamsheetOrder,
+    SkyOrderOptions,
+)
+
+logger = logging.getLogger(__name__)
+
+# Fields on ScreamsheetOrder that control execution but are not sheet keys.
+_SKIP_FIELDS: frozenset[str] = frozenset({"output"})
+
+
+def _copy_to_output_dir(src: str, output_dir: str) -> None:
+    """Copy a generated PDF to the configured output directory.
+
+    No-ops silently when output_dir is empty.  Logs a warning if src is missing.
+    """
+    if not output_dir:
+        return
+    src_path = Path(src)
+    if not src_path.exists():
+        logger.warning("Output copy skipped — file not found: %s", src)
+        return
+    dest = Path(output_dir)
+    dest.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src_path, dest / src_path.name)
+
+
+# ---------------------------------------------------------------------------
+# Per-sheet handlers
+# Each handler signature: (options, today, today_str) -> pdf_path
+# ---------------------------------------------------------------------------
+
+def _run_nhl(options: NHLOrderOptions, today: datetime, today_str: str) -> str:
+    game_date = today - timedelta(days=1)
+    teams = [(t.id, t.name) for t in options.favorite_teams]
+    sheet = ScreamsheetFactory.create_nhl_screamsheet(
+        output_filename=f"Files/NHL_gamescores_{today_str}.pdf",
+        favorite_teams=teams,
+        date=game_date,
+        display_date=today,
+    )
+    return sheet.generate()
+
+
+def _run_mlb(options: MLBOrderOptions, today: datetime, today_str: str) -> str:
+    game_date = today - timedelta(days=1)
+    teams = [(t.id, t.name) for t in options.favorite_teams]
+    sheet = ScreamsheetFactory.create_mlb_screamsheet(
+        output_filename=f"Files/MLB_gamescores_{today_str}.pdf",
+        favorite_teams=teams,
+        date=game_date,
+        display_date=today,
+    )
+    return sheet.generate()
+
+
+def _run_nba(options: NBAOrderOptions, today: datetime, today_str: str) -> str:
+    game_date = today - timedelta(days=1)
+    teams = [(t.id, t.name) for t in options.favorite_teams]
+    sheet = ScreamsheetFactory.create_nba_screamsheet(
+        output_filename=f"Files/NBA_gamescores_{today_str}.pdf",
+        favorite_teams=teams,
+        date=game_date,
+        display_date=today,
+    )
+    return sheet.generate()
+
+
+def _run_nfl(options: NFLOrderOptions, today: datetime, today_str: str) -> str:
+    game_date = today - timedelta(days=1)
+    teams = [(t.id, t.name) for t in options.favorite_teams]
+    sheet = ScreamsheetFactory.create_nfl_screamsheet(
+        output_filename=f"Files/NFL_gamescores_{today_str}.pdf",
+        favorite_teams=teams,
+        date=game_date,
+    )
+    return sheet.generate()
+
+
+def _run_mlb_news(options: MLBNewsOrderOptions, today: datetime, today_str: str) -> str:
+    kwargs: dict[str, Any] = {
+        "output_filename": f"Files/MLB_NEWS_{today_str}.pdf",
+        "favorite_teams": options.news_names or None,
+        "date": today,
+    }
+    if options.weather:
+        kwargs.update(
+            include_weather=True,
+            weather_lat=options.weather.lat,
+            weather_lon=options.weather.lon,
+            weather_location_name=options.weather.location_name,
+        )
+    sheet = ScreamsheetFactory.create_mlb_news_screamsheet(**kwargs)
+    return sheet.generate()
+
+
+def _run_mlb_trade_rumors(
+    options: MLBTradeRumorsOrderOptions, today: datetime, today_str: str
+) -> str:
+    kwargs: dict[str, Any] = {
+        "output_filename": f"Files/MLB_trade_rumors_{today_str}.pdf",
+        "favorite_teams": options.news_names or None,
+        "date": today,
+    }
+    if options.weather:
+        kwargs.update(
+            include_weather=True,
+            weather_lat=options.weather.lat,
+            weather_lon=options.weather.lon,
+            weather_location_name=options.weather.location_name,
+        )
+    sheet = ScreamsheetFactory.create_mlb_trade_rumors_screamsheet(**kwargs)
+    return sheet.generate()
+
+
+def _run_presidential(
+    options: PresidentialOrderOptions, today: datetime, today_str: str
+) -> str:
+    kwargs: dict[str, Any] = {
+        "output_filename": f"Files/presidential_screamsheet_{today_str}.pdf",
+        "date": today,
+    }
+    if options.weather:
+        kwargs.update(
+            include_weather=True,
+            weather_lat=options.weather.lat,
+            weather_lon=options.weather.lon,
+            weather_location_name=options.weather.location_name,
+        )
+    sheet = ScreamsheetFactory.create_presidential_screamsheet(**kwargs)
+    return sheet.generate()
+
+
+def _run_sky(options: SkyOrderOptions, today: datetime, today_str: str) -> str:
+    sheet = ScreamsheetFactory.create_sky_tonight_screamsheet(
+        output_filename=f"Files/SKY_{today_str}.pdf",
+        lat=options.lat,
+        lon=options.lon,
+        location_name=options.location_name,
+        date=today,
+        people=options.people,
+    )
+    return sheet.generate()
+
+
+# ---------------------------------------------------------------------------
+# Registry — maps ScreamsheetOrder field names to their handler functions.
+# To add a new sheet: add a field to ScreamsheetOrder, write a handler above,
+# and add one entry here.  run_order() never needs to change.
+# ---------------------------------------------------------------------------
+
+_REGISTRY: dict[str, Callable[..., str]] = {
+    "nhl":              _run_nhl,
+    "mlb":              _run_mlb,
+    "nba":              _run_nba,
+    "nfl":              _run_nfl,
+    "mlb_news":         _run_mlb_news,
+    "mlb_trade_rumors": _run_mlb_trade_rumors,
+    "presidential":     _run_presidential,
+    "sky":              _run_sky,
+}
+
+
+def run_order(order: ScreamsheetOrder, today: datetime | None = None) -> str:
+    """Generate all sheets specified in *order*.
+
+    Args:
+        order: Describes which sheets to produce and their options.
+               Fields set to ``None`` are skipped.
+        today: Treat this datetime as "today".  Defaults to ``datetime.now()``.
+               Each handler derives the game date as yesterday relative to *today*.
+
+    Returns:
+        ``"success"`` when all requested sheets complete without raising.
+    """
+    if today is None:
+        today = datetime.now()
+    today_str = today.strftime("%Y%m%d")
+    output_dir = order.output.directory if order.output else ""
+
+    for f in dataclasses.fields(order):
+        if f.name in _SKIP_FIELDS:
+            continue
+        options = getattr(order, f.name)
+        if options is None:
+            continue
+        if f.name not in _REGISTRY:
+            logger.warning(
+                "ScreamsheetOrder field '%s' is set but has no registry entry — sheet skipped",
+                f.name,
+            )
+            continue
+        pdf_path = _REGISTRY[f.name](options, today, today_str)
+        logger.info("Generated: %s", pdf_path)
+        if output_dir:
+            dest = str(Path(output_dir) / Path(pdf_path).name)
+            _copy_to_output_dir(pdf_path, output_dir)
+            logger.info("Copied to: %s", dest)
+
+    return "success"

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -1,0 +1,88 @@
+"""Unit tests for the ScreamsheetOrder contract and run_order() dispatcher."""
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from screamsheet.order import (
+    NHLOrderOptions,
+    MLBOrderOptions,
+    OutputOrderOptions,
+    ScreamsheetOrder,
+    TeamEntry,
+    OrderValidationError,
+)
+from screamsheet.runner import run_order
+
+
+_TODAY = datetime(2026, 5, 16)
+
+
+class TestTeamEntryValidation:
+    def test_valid_team_entry_constructs_successfully(self) -> None:
+        entry = TeamEntry(id=4, name="Philadelphia Flyers")
+        assert entry.id == 4
+        assert entry.name == "Philadelphia Flyers"
+
+    def test_zero_id_raises_order_validation_error(self) -> None:
+        with pytest.raises(OrderValidationError):
+            TeamEntry(id=0, name="Bad Team")
+
+    def test_negative_id_raises_order_validation_error(self) -> None:
+        with pytest.raises(OrderValidationError):
+            TeamEntry(id=-1, name="Bad Team")
+
+    def test_empty_name_raises_order_validation_error(self) -> None:
+        with pytest.raises(OrderValidationError):
+            TeamEntry(id=4, name="")
+
+
+class TestRunOrder:
+    def test_empty_order_returns_success(self) -> None:
+        order = ScreamsheetOrder()
+        assert run_order(order, today=_TODAY) == "success"
+
+    def test_nhl_only_order_calls_only_nhl_handler(self) -> None:
+        order = ScreamsheetOrder(
+            nhl=NHLOrderOptions(favorite_teams=[TeamEntry(id=4, name="Flyers")])
+        )
+        mock_nhl = MagicMock(return_value="/tmp/nhl.pdf")
+        mock_mlb = MagicMock(return_value="/tmp/mlb.pdf")
+        with patch("screamsheet.runner._REGISTRY", {"nhl": mock_nhl, "mlb": mock_mlb}):
+            result = run_order(order, today=_TODAY)
+        assert result == "success"
+        mock_nhl.assert_called_once()
+        mock_mlb.assert_not_called()
+
+    def test_no_sheet_keys_produces_zero_handler_calls(self) -> None:
+        order = ScreamsheetOrder(output=OutputOrderOptions(directory="/tmp"))
+        mock_handler = MagicMock(return_value="/tmp/sheet.pdf")
+        with patch("screamsheet.runner._REGISTRY", {"nhl": mock_handler}):
+            result = run_order(order, today=_TODAY)
+        assert result == "success"
+        mock_handler.assert_not_called()
+
+    def test_unregistered_field_logs_warning_and_does_not_raise(self, caplog) -> None:
+        import logging
+
+        order = ScreamsheetOrder(
+            nhl=NHLOrderOptions(favorite_teams=[TeamEntry(id=4, name="Flyers")])
+        )
+        with patch("screamsheet.runner._REGISTRY", {}):
+            with caplog.at_level(logging.WARNING, logger="screamsheet.runner"):
+                result = run_order(order, today=_TODAY)
+        assert result == "success"
+        assert any("nhl" in r.message for r in caplog.records)
+
+    def test_output_field_is_never_dispatched_as_sheet(self) -> None:
+        order = ScreamsheetOrder(output=OutputOrderOptions(directory="/tmp/out"))
+        mock_handler = MagicMock(return_value="/tmp/sheet.pdf")
+        with patch("screamsheet.runner._REGISTRY", {"output": mock_handler}):
+            run_order(order, today=_TODAY)
+        mock_handler.assert_not_called()
+
+    def test_today_defaults_to_now_when_not_provided(self) -> None:
+        order = ScreamsheetOrder()
+        assert run_order(order) == "success"


### PR DESCRIPTION
…oint (#77)

Introduces a formal input contract for the screamsheet engine so that an external orchestration layer can call screamsheet programmatically, without touching config.yaml.

New files:
- src/screamsheet/order.py — ScreamsheetOrder dataclass and all *OrderOptions types (NHL, MLB, NBA, NFL, MLBNews, MLBTradeRumors, Presidential, Sky, Output). Includes OrderValidationError with validation in TeamEntry.__post_init__.
- src/screamsheet/runner.py — run_order(order, today) as the single engine entry point. Uses a _REGISTRY dict to dispatch per sheet type; adding a new sheet requires only a new field on ScreamsheetOrder and one registry entry — run_order() itself never changes. Logs generated path and copy destination for every sheet. Emits a warning (never silently no-ops) when a field has no registry entry.
- tests/test_order.py — 10 unit tests covering TeamEntry validation, registry dispatch, the unregistered-field warning, and the output field guard.
- examples/run_order_example.py — standalone script demonstrating how an orchestration layer imports screamsheet and calls run_order().

Modified files:
- src/screamsheet/__main__.py — adds _build_order_from_config() which translates config.yaml into a ScreamsheetOrder; the default (non-interactive) CLI path now calls run_order() instead of iterating _build_sheets directly. --single still uses the existing _build_sheets / _pick_and_run path. _run_sheet now logs Generated/Copied-to consistently with run_order().
- src/screamsheet/__init__.py — exports ScreamsheetOrder and run_order as public API.

config.yaml is now one possible source of a ScreamsheetOrder, not the only path through the engine. Both the CLI and the orchestration layer converge at run_order().