### PR TITLE
refactor: introduce ScreamsheetResult and refactor runner output

### DIFF
--- a/documentation/CHANGES_FOR_ORCHESTRATION.md
+++ b/documentation/CHANGES_FOR_ORCHESTRATION.md
@@ -1,0 +1,132 @@
+# Screamsheet Engine Changes for Subscriber Orchestration
+
+This document describes the changes required in the `screamsheet` repo to
+support the `screamsheet-subscribers` orchestration system (Phase 2).
+
+See `screamsheet-subscribers/documentation/ORCHESTRATION_PLAN.md` for the
+overall architecture.
+
+---
+
+## Change 1 — `ScreamsheetResult` dataclass (`order.py`)
+
+Add the following dataclass to `src/screamsheet/order.py`:
+
+```python
+from dataclasses import dataclass, field
+
+@dataclass
+class ScreamsheetResult:
+    """Return value of runner.run_order().
+
+    subscriber_name: human-readable label for log / summary email
+    sheets_generated: list of PDF filenames (basename only) written to disk
+    options_summary: sheet_key -> list of option strings for the summary email
+                     e.g. {"mlb": ["Phillies", "Nationals"],
+                            "mlb_news": ["Philadelphia PA"]}
+    errors: non-fatal error messages; empty list == clean run
+    """
+    subscriber_name: str
+    sheets_generated: list[str] = field(default_factory=list)
+    options_summary: dict[str, list[str]] = field(default_factory=dict)
+    errors: list[str] = field(default_factory=list)
+```
+
+`subscriber_name` is supplied by the caller (the orchestrator sets it to the
+subscriber's name from their YAML file).
+
+---
+
+## Change 2 — `run_order()` return type and fault tolerance (`runner.py`)
+
+Current signature:
+```python
+def run_order(order: ScreamsheetOrder, today: datetime | None = None) -> str:
+```
+
+New signature:
+```python
+def run_order(
+    order: ScreamsheetOrder,
+    today: datetime | None = None,
+    subscriber_name: str = "",
+) -> ScreamsheetResult:
+```
+
+**Behaviour changes:**
+
+1. **Per-sheet exception isolation**: each sheet is generated inside a
+   `try/except`. If a sheet raises, the exception message is appended to
+   `result.errors` and the loop continues to the next sheet.
+   A failed sheet does NOT appear in `result.sheets_generated`.
+
+2. **Return value**: return a `ScreamsheetResult` with all fields populated
+   instead of the literal string `"success"`.
+
+3. **`options_summary` population**: after each successful sheet, append a
+   human-readable list of options. Minimum requirement:
+   - Sport sheets: list of team names (from `TeamEntry.name`)
+   - News/weather sheets: `location_name` string (e.g. `"Bryn Mawr, PA"`) if weather is present
+   - Boolean sheets: `["enabled"]`
+
+---
+
+## Change 3 — Write PDFs directly to `output.directory` (`runner.py`)
+
+Currently `run_order()` writes PDFs to `Files/<name>_<date>.pdf` and then
+copies them to `output.directory`.
+
+**Change**: write directly to `output.directory` and remove the intermediate
+`Files/` write + copy step.
+
+The orchestrator always sets `order.output.directory` to a dedicated staging
+subdirectory (e.g. `staging/peter_20260519_063000/`). The `Files/` directory
+should no longer be used as an intermediary.
+
+> **Note**: if any other callers (e.g. `examples/run_order_example.py`,
+> `screamsheet.sh`) rely on `Files/` being populated as a side effect, update
+> those callers to set an explicit `output.directory`.
+
+---
+
+## Change 4 — Verify `weather=None` guard in renderers (`order.py` already done)
+
+`MLBNewsOrderOptions`, `MLBTradeRumorsOrderOptions`, and `PresidentialOrderOptions`
+already declare `weather: WeatherLocationOptions | None = None` in `order.py`
+(no change needed there).
+
+What must be verified: when `weather=None`, does the renderer skip the weather
+section silently? If not, add a guard:
+
+```python
+if options.weather is not None:
+    render_weather_section(canvas, options.weather, ...)
+```
+
+With `peter-test.yaml` always supplying `lat`/`lon`/`location_name` for all
+weather-capable sheets, this path may be untested. Add a test that passes
+`weather=None` and confirms the PDF renders without error.
+
+---
+
+## Summary of files to change
+
+| File | Change |
+|------|--------|
+| `src/screamsheet/order.py` | Add `ScreamsheetResult` dataclass |
+| `src/screamsheet/runner.py` | Update `run_order()` return type, add `subscriber_name` param, add per-sheet fault tolerance, write directly to `output.directory` |
+| Relevant renderer(s) | Verify/add `weather=None` guard (see Change 4) |
+| `examples/run_order_example.py` | Update to set explicit `output.directory` |
+| `tests/` | Add tests for `ScreamsheetResult`, fault tolerance, direct output path, `weather=None` render |
+
+---
+
+## Acceptance criteria
+
+- `run_order()` returns a `ScreamsheetResult` (not `"success"`)
+- A sheet that raises an exception does not prevent other sheets from running
+- The raised exception message appears in `result.errors`
+- PDFs appear in `order.output.directory`, not in `Files/`
+- A news sheet order with `weather=None` renders without error and without a
+  weather section
+- All existing tests remain green

--- a/src/screamsheet/order.py
+++ b/src/screamsheet/order.py
@@ -140,3 +140,13 @@ class ScreamsheetOrder:
     mlb_trade_rumors: MLBTradeRumorsOrderOptions | None = None
     presidential: PresidentialOrderOptions | None = None
     sky: SkyOrderOptions | None = None
+
+
+@dataclass
+class ScreamsheetResult:
+    """Return value of runner.run_order()."""
+
+    subscriber_name: str
+    sheets_generated: list[str] = field(default_factory=list)
+    options_summary: dict[str, list[str]] = field(default_factory=dict)
+    errors: list[str] = field(default_factory=list)

--- a/src/screamsheet/runner.py
+++ b/src/screamsheet/runner.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-import shutil
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Callable
@@ -24,6 +23,7 @@ from .order import (
     NHLOrderOptions,
     PresidentialOrderOptions,
     ScreamsheetOrder,
+    ScreamsheetResult,
     SkyOrderOptions,
 )
 
@@ -33,32 +33,37 @@ logger = logging.getLogger(__name__)
 _SKIP_FIELDS: frozenset[str] = frozenset({"output"})
 
 
-def _copy_to_output_dir(src: str, output_dir: str) -> None:
-    """Copy a generated PDF to the configured output directory.
+def _output_path(output_dir: str, basename: str) -> str:
+    """Return the full path for a generated PDF.
 
-    No-ops silently when output_dir is empty.  Logs a warning if src is missing.
+    Writes directly into *output_dir* when set; falls back to Files/ for
+    backward-compatible standalone use.
     """
-    if not output_dir:
-        return
-    src_path = Path(src)
-    if not src_path.exists():
-        logger.warning("Output copy skipped — file not found: %s", src)
-        return
-    dest = Path(output_dir)
-    dest.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(src_path, dest / src_path.name)
+    if output_dir:
+        return str(Path(output_dir) / basename)
+    return f"Files/{basename}"
+
+
+def _options_summary_entry(field_name: str, options: Any) -> list[str]:
+    """Extract a human-readable summary list from a sheet options object."""
+    if field_name in ("nhl", "mlb", "nba", "nfl"):
+        return [t.name for t in getattr(options, "favorite_teams", [])]
+    if field_name in ("mlb_news", "mlb_trade_rumors", "presidential"):
+        weather = getattr(options, "weather", None)
+        return [weather.location_name] if weather else []
+    return []
 
 
 # ---------------------------------------------------------------------------
 # Per-sheet handlers
-# Each handler signature: (options, today, today_str) -> pdf_path
+# Each handler signature: (options, today, today_str, output_dir) -> pdf_path
 # ---------------------------------------------------------------------------
 
-def _run_nhl(options: NHLOrderOptions, today: datetime, today_str: str) -> str:
+def _run_nhl(options: NHLOrderOptions, today: datetime, today_str: str, output_dir: str) -> str:
     game_date = today - timedelta(days=1)
     teams = [(t.id, t.name) for t in options.favorite_teams]
     sheet = ScreamsheetFactory.create_nhl_screamsheet(
-        output_filename=f"Files/NHL_gamescores_{today_str}.pdf",
+        output_filename=_output_path(output_dir, f"NHL_gamescores_{today_str}.pdf"),
         favorite_teams=teams,
         date=game_date,
         display_date=today,
@@ -66,11 +71,11 @@ def _run_nhl(options: NHLOrderOptions, today: datetime, today_str: str) -> str:
     return sheet.generate()
 
 
-def _run_mlb(options: MLBOrderOptions, today: datetime, today_str: str) -> str:
+def _run_mlb(options: MLBOrderOptions, today: datetime, today_str: str, output_dir: str) -> str:
     game_date = today - timedelta(days=1)
     teams = [(t.id, t.name) for t in options.favorite_teams]
     sheet = ScreamsheetFactory.create_mlb_screamsheet(
-        output_filename=f"Files/MLB_gamescores_{today_str}.pdf",
+        output_filename=_output_path(output_dir, f"MLB_gamescores_{today_str}.pdf"),
         favorite_teams=teams,
         date=game_date,
         display_date=today,
@@ -78,11 +83,11 @@ def _run_mlb(options: MLBOrderOptions, today: datetime, today_str: str) -> str:
     return sheet.generate()
 
 
-def _run_nba(options: NBAOrderOptions, today: datetime, today_str: str) -> str:
+def _run_nba(options: NBAOrderOptions, today: datetime, today_str: str, output_dir: str) -> str:
     game_date = today - timedelta(days=1)
     teams = [(t.id, t.name) for t in options.favorite_teams]
     sheet = ScreamsheetFactory.create_nba_screamsheet(
-        output_filename=f"Files/NBA_gamescores_{today_str}.pdf",
+        output_filename=_output_path(output_dir, f"NBA_gamescores_{today_str}.pdf"),
         favorite_teams=teams,
         date=game_date,
         display_date=today,
@@ -90,20 +95,22 @@ def _run_nba(options: NBAOrderOptions, today: datetime, today_str: str) -> str:
     return sheet.generate()
 
 
-def _run_nfl(options: NFLOrderOptions, today: datetime, today_str: str) -> str:
+def _run_nfl(options: NFLOrderOptions, today: datetime, today_str: str, output_dir: str) -> str:
     game_date = today - timedelta(days=1)
     teams = [(t.id, t.name) for t in options.favorite_teams]
     sheet = ScreamsheetFactory.create_nfl_screamsheet(
-        output_filename=f"Files/NFL_gamescores_{today_str}.pdf",
+        output_filename=_output_path(output_dir, f"NFL_gamescores_{today_str}.pdf"),
         favorite_teams=teams,
         date=game_date,
     )
     return sheet.generate()
 
 
-def _run_mlb_news(options: MLBNewsOrderOptions, today: datetime, today_str: str) -> str:
+def _run_mlb_news(
+    options: MLBNewsOrderOptions, today: datetime, today_str: str, output_dir: str
+) -> str:
     kwargs: dict[str, Any] = {
-        "output_filename": f"Files/MLB_NEWS_{today_str}.pdf",
+        "output_filename": _output_path(output_dir, f"MLB_NEWS_{today_str}.pdf"),
         "favorite_teams": options.news_names or None,
         "date": today,
     }
@@ -119,10 +126,10 @@ def _run_mlb_news(options: MLBNewsOrderOptions, today: datetime, today_str: str)
 
 
 def _run_mlb_trade_rumors(
-    options: MLBTradeRumorsOrderOptions, today: datetime, today_str: str
+    options: MLBTradeRumorsOrderOptions, today: datetime, today_str: str, output_dir: str
 ) -> str:
     kwargs: dict[str, Any] = {
-        "output_filename": f"Files/MLB_trade_rumors_{today_str}.pdf",
+        "output_filename": _output_path(output_dir, f"MLB_trade_rumors_{today_str}.pdf"),
         "favorite_teams": options.news_names or None,
         "date": today,
     }
@@ -138,10 +145,10 @@ def _run_mlb_trade_rumors(
 
 
 def _run_presidential(
-    options: PresidentialOrderOptions, today: datetime, today_str: str
+    options: PresidentialOrderOptions, today: datetime, today_str: str, output_dir: str
 ) -> str:
     kwargs: dict[str, Any] = {
-        "output_filename": f"Files/presidential_screamsheet_{today_str}.pdf",
+        "output_filename": _output_path(output_dir, f"presidential_screamsheet_{today_str}.pdf"),
         "date": today,
     }
     if options.weather:
@@ -155,9 +162,9 @@ def _run_presidential(
     return sheet.generate()
 
 
-def _run_sky(options: SkyOrderOptions, today: datetime, today_str: str) -> str:
+def _run_sky(options: SkyOrderOptions, today: datetime, today_str: str, output_dir: str) -> str:
     sheet = ScreamsheetFactory.create_sky_tonight_screamsheet(
-        output_filename=f"Files/SKY_{today_str}.pdf",
+        output_filename=_output_path(output_dir, f"SKY_{today_str}.pdf"),
         lat=options.lat,
         lon=options.lon,
         location_name=options.location_name,
@@ -169,8 +176,6 @@ def _run_sky(options: SkyOrderOptions, today: datetime, today_str: str) -> str:
 
 # ---------------------------------------------------------------------------
 # Registry — maps ScreamsheetOrder field names to their handler functions.
-# To add a new sheet: add a field to ScreamsheetOrder, write a handler above,
-# and add one entry here.  run_order() never needs to change.
 # ---------------------------------------------------------------------------
 
 _REGISTRY: dict[str, Callable[..., str]] = {
@@ -185,22 +190,33 @@ _REGISTRY: dict[str, Callable[..., str]] = {
 }
 
 
-def run_order(order: ScreamsheetOrder, today: datetime | None = None) -> str:
+def run_order(
+    order: ScreamsheetOrder,
+    today: datetime | None = None,
+    subscriber_name: str = "",
+) -> ScreamsheetResult:
     """Generate all sheets specified in *order*.
 
     Args:
         order: Describes which sheets to produce and their options.
                Fields set to ``None`` are skipped.
         today: Treat this datetime as "today".  Defaults to ``datetime.now()``.
-               Each handler derives the game date as yesterday relative to *today*.
+        subscriber_name: Label embedded in the returned result for reporting.
 
     Returns:
-        ``"success"`` when all requested sheets complete without raising.
+        A ``ScreamsheetResult`` describing what was generated and any errors.
+        Per-sheet exceptions are caught; the sheet is added to errors and the
+        loop continues.
     """
     if today is None:
         today = datetime.now()
     today_str = today.strftime("%Y%m%d")
     output_dir = order.output.directory if order.output else ""
+
+    if output_dir:
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    result = ScreamsheetResult(subscriber_name=subscriber_name)
 
     for f in dataclasses.fields(order):
         if f.name in _SKIP_FIELDS:
@@ -214,11 +230,14 @@ def run_order(order: ScreamsheetOrder, today: datetime | None = None) -> str:
                 f.name,
             )
             continue
-        pdf_path = _REGISTRY[f.name](options, today, today_str)
-        logger.info("Generated: %s", pdf_path)
-        if output_dir:
-            dest = str(Path(output_dir) / Path(pdf_path).name)
-            _copy_to_output_dir(pdf_path, output_dir)
-            logger.info("Copied to: %s", dest)
+        try:
+            pdf_path = _REGISTRY[f.name](options, today, today_str, output_dir)
+            logger.info("Generated: %s", pdf_path)
+            result.sheets_generated.append(Path(pdf_path).name)
+            result.options_summary[f.name] = _options_summary_entry(f.name, options)
+        except Exception as exc:
+            logger.error("Sheet '%s' failed: %s", f.name, exc)
+            result.errors.append(f"{f.name}: {exc}")
 
-    return "success"
+    return result
+

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -12,6 +12,7 @@ from screamsheet.order import (
     OutputOrderOptions,
     PersonOptions,
     ScreamsheetOrder,
+    ScreamsheetResult,
     TeamEntry,
     OrderValidationError,
 )
@@ -41,9 +42,12 @@ class TestTeamEntryValidation:
 
 
 class TestRunOrder:
-    def test_empty_order_returns_success(self) -> None:
+    def test_empty_order_returns_clean_result(self) -> None:
         order = ScreamsheetOrder()
-        assert run_order(order, today=_TODAY) == "success"
+        result = run_order(order, today=_TODAY)
+        assert isinstance(result, ScreamsheetResult)
+        assert result.errors == []
+        assert result.sheets_generated == []
 
     def test_nhl_only_order_calls_only_nhl_handler(self) -> None:
         order = ScreamsheetOrder(
@@ -53,7 +57,7 @@ class TestRunOrder:
         mock_mlb = MagicMock(return_value="/tmp/mlb.pdf")
         with patch("screamsheet.runner._REGISTRY", {"nhl": mock_nhl, "mlb": mock_mlb}):
             result = run_order(order, today=_TODAY)
-        assert result == "success"
+        assert isinstance(result, ScreamsheetResult)
         mock_nhl.assert_called_once()
         mock_mlb.assert_not_called()
 
@@ -62,7 +66,7 @@ class TestRunOrder:
         mock_handler = MagicMock(return_value="/tmp/sheet.pdf")
         with patch("screamsheet.runner._REGISTRY", {"nhl": mock_handler}):
             result = run_order(order, today=_TODAY)
-        assert result == "success"
+        assert isinstance(result, ScreamsheetResult)
         mock_handler.assert_not_called()
 
     def test_unregistered_field_logs_warning_and_does_not_raise(self, caplog) -> None:
@@ -74,7 +78,7 @@ class TestRunOrder:
         with patch("screamsheet.runner._REGISTRY", {}):
             with caplog.at_level(logging.WARNING, logger="screamsheet.runner"):
                 result = run_order(order, today=_TODAY)
-        assert result == "success"
+        assert isinstance(result, ScreamsheetResult)
         assert any("nhl" in r.message for r in caplog.records)
 
     def test_output_field_is_never_dispatched_as_sheet(self) -> None:
@@ -86,7 +90,24 @@ class TestRunOrder:
 
     def test_today_defaults_to_now_when_not_provided(self) -> None:
         order = ScreamsheetOrder()
-        assert run_order(order) == "success"
+        result = run_order(order)
+        assert isinstance(result, ScreamsheetResult)
+
+    def test_sheet_exception_is_captured_in_errors_not_raised(self) -> None:
+        order = ScreamsheetOrder(
+            nhl=NHLOrderOptions(favorite_teams=[TeamEntry(id=4, name="Flyers")])
+        )
+        mock_nhl = MagicMock(side_effect=RuntimeError("network timeout"))
+        with patch("screamsheet.runner._REGISTRY", {"nhl": mock_nhl}):
+            result = run_order(order, today=_TODAY)
+        assert isinstance(result, ScreamsheetResult)
+        assert any("network timeout" in e for e in result.errors)
+        assert result.sheets_generated == []
+
+    def test_subscriber_name_appears_in_result(self) -> None:
+        order = ScreamsheetOrder()
+        result = run_order(order, today=_TODAY, subscriber_name="Peter Martinson")
+        assert result.subscriber_name == "Peter Martinson"
 
 
 class TestPersonOptions:


### PR DESCRIPTION
- Add ScreamsheetResult dataclass to order.py for standardized run results
- Refactor runner.py to use ScreamsheetResult, improve output path logic, and clean up imports
- Update and expand test_order.py for new result structure
- Prep for orchestration integration and more robust downstream handling