### PR TITLE
feat(db): extend SQLite cache to all four sports with configurable DB…

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -42,6 +42,7 @@ jobs:
           #    This overwrites the developer's local config.yaml that rsync copied above.
           sed \
             -e 's|__PRINT_DIR__|${{ vars.PRINT_DIR }}|g' \
+            -e 's|__DB_PATH__|${{ vars.DB_PATH }}|g' \
             -e 's|__PERSON1_NAME__|${{ vars.PERSON1_NAME }}|g' \
             -e 's|__PERSON1_SUN_SIGN__|${{ vars.PERSON1_SUN_SIGN }}|g' \
             -e 's|__PERSON1_MOON_SIGN__|${{ vars.PERSON1_MOON_SIGN }}|g' \

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -76,6 +76,13 @@ sky:
       moon_sign: "__PERSON2_MOON_SIGN__"
       ascendant: "__PERSON2_ASCENDANT__"
 
+# Database path for the SQLite team/player cache.
+# The SCREAMSHEET_DB environment variable takes precedence if set.
+# In CI, __DB_PATH__ is substituted by the deploy workflow using the
+# DB_PATH GitHub repository variable.
+database:
+  path: __DB_PATH__
+
 # Output directory: generated PDFs are copied here after generation.
 # Override per-run with: uv run screamsheet --output-dir /path/to/dir
 # In CI, __PRINT_DIR__ is substituted by the deploy workflow using the

--- a/documentation/database-setup/ISSUE_84_TEAM_SYNC.md
+++ b/documentation/database-setup/ISSUE_84_TEAM_SYNC.md
@@ -1,0 +1,41 @@
+# Recreate team lookup DB and sync scripts from current screamsheet.db 
+## Problem
+After running the latest branch, my local `screamsheet.db` already contains team tables for all four sports (NHL, MLB, NBA, NFL), and the data appears fully populated. Rather than merging the whole branch or cherry-picking, I want to generate a fresh, clean set of scripts and modules for:
+- team lookup table schema
+- team sync scripts (one per sport)
+- lookup helpers (e.g. lookup by full name or abbreviation)
+- relevant tests
+
+## Goal
+Use Copilot (or another local LLM) to examine the schemas and contents of my existing local `screamsheet.db`, then generate the code described above in `screamsheet/db/`, matching the actual DB as source of truth.
+
+---
+
+## Exact Prompt to Copilot
+
+> I have a SQLite database at `~/database/screamsheet.db` that is already populated with team tables for all four sports (NHL, MLB, NBA, NFL). I want to create the Python scripts in `src/screamsheet/db/` that:
+> 
+> 1. Define SQLAlchemy ORM models for the current schema of each team table found in the DB (one model per sport, matching table and column names exactly as in the DB).
+> 2. Implement upsert helpers for each table, ensuring idempotent insertion based on the unique team ID (e.g. `team_id`).
+> 3. Provide lookup helpers to search by canonical team name, abbreviation, or numeric ID, returning full row dicts.
+> 4. Create a sync script for each sport (e.g. `mlb_teams_sync.py`, etc.) that pulls from the relevant public sports API and upserts into the proper table, matching columns and datatypes as found in the DB.
+> 5. Add a generic test that (a) creates an in-memory SQLite DB using these models, (b) populates it with a sample team, (c) exercises each lookup and upsert helper, and (d) verifies all results match expectations.
+> 
+> To start, connect with a SQLite DB explorer (or `sqlite3`) and for each team table, output:
+> - Table name
+> - Full `CREATE TABLE` statement
+> - A few representative rows (SELECT * LIMIT 2)
+> 
+> Then, generate each script one-by-one, verifying that schema/column types in your code exactly match the DB. Do not fall back on previous repo code; treat the DB as ground truth.
+
+---
+
+## Acceptance Criteria
+- All generated Python code matches the schema and contents of the current local DB
+- Upsert is idempotent (no duplicates on repeated runs)
+- Lookups by full name, abbreviation, or ID work as expected
+- Test suite passes on the new helpers
+
+---
+
+**This issue is the canonical prompt and results checkpoint. Paste all generated scripts and test results as a comment or PR linked here.**

--- a/src/screamsheet/__main__.py
+++ b/src/screamsheet/__main__.py
@@ -290,6 +290,16 @@ def main():
 
     today = datetime.strptime(today_str, "%Y%m%d")
 
+    # Apply database path from config before any DB access.
+    # os.environ.setdefault leaves an already-exported SCREAMSHEET_DB untouched.
+    import os
+    try:
+        _db_cfg = load_config()
+        if _db_cfg.database.path:
+            os.environ.setdefault("SCREAMSHEET_DB", _db_cfg.database.path)
+    except FileNotFoundError:
+        pass  # config.yaml missing — env var / platform default will be used
+
     if args.single:
         sheets, output_dir = _build_sheets(today_str)
         if args.output_dir:

--- a/src/screamsheet/config.py
+++ b/src/screamsheet/config.py
@@ -82,6 +82,17 @@ class OutputConfig:
 
 
 @dataclass
+class DbConfig:
+    """Database path configuration.
+
+    Leave ``path`` empty to use the platform default (~/database/screamsheet.db).
+    Set it to override, e.g. for a non-standard deployment location.
+    The SCREAMSHEET_DB environment variable takes precedence over this setting.
+    """
+    path: str = ""
+
+
+@dataclass
 class ScreamsheetConfig:
     """Top-level config object, one SportConfig per sport."""
     nhl: SportConfig = field(default_factory=SportConfig)
@@ -92,12 +103,17 @@ class ScreamsheetConfig:
     sky: SkyConfig = field(default_factory=SkyConfig)
     branding: str = ""
     output: OutputConfig = field(default_factory=OutputConfig)
+    database: DbConfig = field(default_factory=DbConfig)
 
 
 def _parse_output(raw: dict) -> OutputConfig:
     return OutputConfig(
         directory=str(raw.get("directory", "")),
     )
+
+
+def _parse_db(raw: dict) -> DbConfig:
+    return DbConfig(path=str(raw.get("path", "")))
 
 
 def _parse_sport(raw: dict) -> SportConfig:
@@ -191,4 +207,5 @@ def load_config(path: Path = _CONFIG_PATH) -> ScreamsheetConfig:
         sky=_parse_sky(raw.get("sky", {})),
         branding=str(raw.get("branding", "")),
         output=_parse_output(raw.get("output", {})),
+        database=_parse_db(raw.get("database", {})),
     )

--- a/src/screamsheet/db/__init__.py
+++ b/src/screamsheet/db/__init__.py
@@ -1,17 +1,24 @@
-"""NHL SQLite cache package (nhl.db).
+"""Screamsheet SQLite cache package (screamsheet.db).
 
-Public API — players:
-    get_db_path()                           Platform-appropriate DB file path
-    init_db(db_path)                        Create the DB and tables
-    upsert_players(players, db_path)        Bulk upsert player dicts
-    lookup_player_by_id(player_id)          Cache lookup by NHL player ID
-    lookup_player_by_name(last, first)      Cache lookup by name (case-insensitive)
-    lookup_player(player_id, ...)           Orchestrator: cache → API fallback
+Public API — NHL players (legacy):
+    get_db_path()                                    Resolved DB file path
+    init_db(db_path)                                 Create the DB and tables
+    upsert_players(players, db_path)                 Bulk upsert player dicts
+    lookup_player_by_id(player_id)                   Cache lookup by NHL player ID
+    lookup_player_by_name(last, first)               Cache lookup by name
+    lookup_player(player_id, ...)                    Orchestrator: cache → API fallback
 
-Public API — teams:
-    upsert_teams(teams, db_path)            Bulk upsert team dicts
-    lookup_team_by_id(team_id)              Cache lookup by NHL numeric team ID
-    lookup_team_by_abbrev(abbrev)           Cache lookup by 3-letter abbreviation
+Public API — NHL teams (legacy, targets 'teams' table):
+    upsert_nhl_teams(teams, db_path)                 Bulk upsert team dicts
+    lookup_nhl_team_by_id(team_id)                   Cache lookup by NHL numeric ID
+    lookup_nhl_team_by_abbrev(abbrev)                Cache lookup by 3-letter abbrev
+
+Public API — multi-sport team lookup (targets '<sport>_teams' tables):
+    sport_init_db(sport, db_path)                    Create sport table if missing
+    sport_upsert_teams(sport, teams, db_path)        Bulk upsert team dicts
+    sport_lookup_by_id(sport, team_id, db_path)      → dict | None
+    sport_lookup_by_abbrev(sport, abbrev, db_path)   → dict | None
+    sport_lookup_by_name(sport, fragment, db_path)   → list[dict]
 """
 
 from .nhl_players_db import (
@@ -23,19 +30,35 @@ from .nhl_players_db import (
     upsert_players,
 )
 from .nhl_teams_db import (
-    lookup_team_by_abbrev,
-    lookup_team_by_id,
-    upsert_teams,
+    lookup_team_by_abbrev as lookup_nhl_team_by_abbrev,
+    lookup_team_by_id as lookup_nhl_team_by_id,
+    upsert_teams as upsert_nhl_teams,
+)
+from .team_lookup_db import (
+    init_db as sport_init_db,
+    lookup_team_by_abbrev as sport_lookup_by_abbrev,
+    lookup_team_by_id as sport_lookup_by_id,
+    lookup_team_by_name as sport_lookup_by_name,
+    upsert_teams as sport_upsert_teams,
 )
 
 __all__ = [
+    # DB path
     "get_db_path",
+    # NHL players (legacy)
     "init_db",
     "lookup_player",
     "lookup_player_by_id",
     "lookup_player_by_name",
     "upsert_players",
-    "lookup_team_by_abbrev",
-    "lookup_team_by_id",
-    "upsert_teams",
+    # NHL teams (legacy)
+    "lookup_nhl_team_by_abbrev",
+    "lookup_nhl_team_by_id",
+    "upsert_nhl_teams",
+    # Multi-sport team lookup
+    "sport_init_db",
+    "sport_lookup_by_abbrev",
+    "sport_lookup_by_id",
+    "sport_lookup_by_name",
+    "sport_upsert_teams",
 ]

--- a/src/screamsheet/db/_nhl_db_shared.py
+++ b/src/screamsheet/db/_nhl_db_shared.py
@@ -1,9 +1,16 @@
-"""Shared SQLAlchemy base and DB-path helper for the NHL SQLite cache.
+"""Shared SQLAlchemy base and DB-path helper for the screamsheet SQLite cache.
 
-All ORM models that live in nhl.db import _Base from this module so that
-SQLAlchemy's metadata is unified under one DeclarativeBase instance.
+All ORM models import _Base from this module so that SQLAlchemy's metadata
+is unified under one DeclarativeBase instance.  All tables live in a single
+database file (screamsheet.db).
+
+DB path resolution order:
+    1. SCREAMSHEET_DB environment variable (if set)
+    2. Platform default: ~/database/screamsheet.db  (Linux / macOS)
+                         C:\\database\\screamsheet.db (Windows)
 """
 
+import os
 import sys
 from pathlib import Path
 
@@ -15,11 +22,14 @@ class _Base(DeclarativeBase):
 
 
 def get_db_path() -> Path:
-    """Return the platform-appropriate path for the NHL database.
+    """Return the resolved path to the screamsheet SQLite database.
 
-    Linux / macOS:  ~/database/nhl.db
-    Windows:        C:\\database\\nhl.db
+    Checks the SCREAMSHEET_DB environment variable first, then falls back
+    to the platform default (~/database/screamsheet.db).
     """
+    env = os.environ.get("SCREAMSHEET_DB")
+    if env:
+        return Path(env)
     if sys.platform.startswith("win"):
-        return Path("C:/database/nhl.db")
-    return Path.home() / "database" / "nhl.db"
+        return Path("C:/database/screamsheet.db")
+    return Path.home() / "database" / "screamsheet.db"

--- a/src/screamsheet/db/db_update.py
+++ b/src/screamsheet/db/db_update.py
@@ -1,15 +1,15 @@
-"""CLI entry point for syncing the NHL database.
+"""CLI entry point for syncing all sport databases.
 
-Runs the full teams-and-players sync and prints counts to stdout so that
-callers (e.g. update_db.sh) can capture them in a log file.
+Runs team and player syncs for all supported sports and prints counts to
+stdout so that callers (e.g. update_db.sh) can capture them in a log file.
 
 Usage:
     uv run db_update
     uv run db_update --db /path/to/custom.db
 
 Exit codes:
-    0 — both syncs completed and returned non-zero row counts
-    1 — a sync raised an exception or returned zero rows (silent network failure)
+    0 — all syncs completed with non-zero row counts
+    1 — any sync raised an exception or returned zero rows
 """
 
 import argparse
@@ -17,41 +17,51 @@ import sys
 from pathlib import Path
 
 from ._nhl_db_shared import get_db_path
-from .nhl_teams_sync import full_sync_teams
-from .nhl_players_sync import full_sync
+from .nhl_teams_sync import full_sync_canonical_teams, full_sync_teams
+from .nhl_players_sync import full_sync as full_sync_players
+from .mlb_teams_sync import full_sync as mlb_full_sync
+from .nba_teams_sync import full_sync as nba_full_sync
+from .nfl_teams_sync import full_sync as nfl_full_sync
+
+
+def _run(label: str, fn, db: Path) -> bool:
+    """Run one sync function, print its count, return False on failure."""
+    try:
+        count = fn(db)
+        print(f"{label}:{count}")
+        if count == 0:
+            print(f"WARNING: zero rows for {label} — possible network failure.", file=sys.stderr)
+            return False
+        return True
+    except Exception as exc:
+        print(f"ERROR: {label} failed: {exc}", file=sys.stderr)
+        return False
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Sync NHL teams and players into the local database.")
+    parser = argparse.ArgumentParser(
+        description="Sync all sport teams and NHL players into the local database."
+    )
     parser.add_argument(
         "--db",
         type=Path,
         default=None,
-        help="Path to the SQLite database file (default: %(default)s → uses platform default)",
+        help="Path to the SQLite database file (default: platform default)",
     )
     args = parser.parse_args()
 
     db = args.db or get_db_path()
     print(f"Using DB: {db}")
 
-    try:
-        teams = full_sync_teams(db)
-        print(f"teams_upserted:{teams}")
-        if teams == 0:
-            print("WARNING: zero teams upserted — possible network failure.", file=sys.stderr)
-            sys.exit(1)
-    except Exception as exc:
-        print(f"ERROR: teams sync failed: {exc}", file=sys.stderr)
-        sys.exit(1)
+    ok = True
+    ok &= _run("nhl_teams_legacy_upserted",    full_sync_teams,           db)
+    ok &= _run("nhl_teams_upserted",           full_sync_canonical_teams, db)
+    ok &= _run("mlb_teams_upserted",           mlb_full_sync,             db)
+    ok &= _run("nba_teams_upserted",           nba_full_sync,             db)
+    ok &= _run("nfl_teams_upserted",           nfl_full_sync,             db)
+    ok &= _run("nhl_players_upserted",         full_sync_players,         db)
 
-    try:
-        players = full_sync(db)
-        print(f"players_upserted:{players}")
-        if players == 0:
-            print("WARNING: zero players upserted — possible network failure.", file=sys.stderr)
-            sys.exit(1)
-    except Exception as exc:
-        print(f"ERROR: players sync failed: {exc}", file=sys.stderr)
+    if not ok:
         sys.exit(1)
 
 

--- a/src/screamsheet/db/mlb_teams_sync.py
+++ b/src/screamsheet/db/mlb_teams_sync.py
@@ -1,0 +1,75 @@
+"""Full sync of MLB team data into the local SQLite cache.
+
+Fetches all active MLB teams from the MLB Stats API and upserts every
+team record into the mlb_teams table.
+
+Usage:
+    uv run python -m screamsheet.db.mlb_teams_sync
+
+Cron example (Linux) — every Sunday at 3 am:
+    0 3 * * 0 cd /path/to/screamsheet && uv run python -m screamsheet.db.mlb_teams_sync
+"""
+
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+import requests
+
+from ._nhl_db_shared import get_db_path
+from .team_lookup_db import init_db, upsert_teams
+
+logger = logging.getLogger(__name__)
+
+_MLB_TEAMS_URL = "https://statsapi.mlb.com/api/v1/teams?sportId=1"
+
+
+def fetch_teams() -> List[dict]:
+    """Fetch all active MLB teams from the MLB Stats API.
+
+    Returns:
+        List of team dicts ready to pass to upsert_teams().
+
+    Raises:
+        requests.exceptions.HTTPError: on a non-2xx response.
+    """
+    response = requests.get(_MLB_TEAMS_URL, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+
+    teams = []
+    for team in data.get("teams", []):
+        team_id = team.get("id")
+        full_name = team.get("name", "")
+        abbrev = team.get("abbreviation", "")
+        if team_id and full_name:
+            teams.append({
+                "team_id":  team_id,
+                "full_name": full_name,
+                "abbrev":   abbrev,
+            })
+
+    return teams
+
+
+def full_sync(db_path: Optional[Path] = None) -> int:
+    """Fetch all MLB teams and upsert them into the local cache.
+
+    Args:
+        db_path: Path to the SQLite file.  Defaults to get_db_path().
+
+    Returns:
+        Number of rows upserted.
+    """
+    init_db("mlb", db_path)
+    teams = fetch_teams()
+    logger.info("mlb full_sync: fetched %d teams", len(teams))
+    count = upsert_teams("mlb", teams, db_path)
+    logger.info("mlb full_sync: complete — %d teams upserted", count)
+    return count
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    rows = full_sync()
+    print(f"MLB sync complete: {rows} teams upserted to {get_db_path()}")

--- a/src/screamsheet/db/nba_teams_sync.py
+++ b/src/screamsheet/db/nba_teams_sync.py
@@ -1,0 +1,68 @@
+"""Full sync of NBA team data into the local SQLite cache.
+
+Fetches all NBA teams from the nba_api static data (no network call needed)
+and upserts every team record into the nba_teams table.
+
+Usage:
+    uv run python -m screamsheet.db.nba_teams_sync
+
+Cron example (Linux) — every Sunday at 3 am:
+    0 3 * * 0 cd /path/to/screamsheet && uv run python -m screamsheet.db.nba_teams_sync
+"""
+
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+from ._nhl_db_shared import get_db_path
+from .team_lookup_db import init_db, upsert_teams
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_teams() -> List[dict]:
+    """Return all NBA teams from the nba_api static dataset.
+
+    Uses nba_api.stats.static.teams — no network request required.
+
+    Returns:
+        List of team dicts ready to pass to upsert_teams().
+    """
+    from nba_api.stats.static import teams as nba_static
+
+    teams = []
+    for t in nba_static.get_teams():
+        team_id = t.get("id")
+        full_name = t.get("full_name", "")
+        abbrev = t.get("abbreviation", "")
+        if team_id and full_name:
+            teams.append({
+                "team_id":  team_id,
+                "full_name": full_name,
+                "abbrev":   abbrev,
+            })
+
+    return teams
+
+
+def full_sync(db_path: Optional[Path] = None) -> int:
+    """Fetch all NBA teams and upsert them into the local cache.
+
+    Args:
+        db_path: Path to the SQLite file.  Defaults to get_db_path().
+
+    Returns:
+        Number of rows upserted.
+    """
+    init_db("nba", db_path)
+    teams = fetch_teams()
+    logger.info("nba full_sync: fetched %d teams", len(teams))
+    count = upsert_teams("nba", teams, db_path)
+    logger.info("nba full_sync: complete — %d teams upserted", count)
+    return count
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    rows = full_sync()
+    print(f"NBA sync complete: {rows} teams upserted to {get_db_path()}")

--- a/src/screamsheet/db/nfl_teams_sync.py
+++ b/src/screamsheet/db/nfl_teams_sync.py
@@ -1,0 +1,91 @@
+"""Full sync of NFL team data into the local SQLite cache.
+
+Fetches all NFL teams from the ESPN API and upserts every team record
+into the nfl_teams table.
+
+Usage:
+    uv run python -m screamsheet.db.nfl_teams_sync
+
+Cron example (Linux) — every Sunday at 3 am:
+    0 3 * * 0 cd /path/to/screamsheet && uv run python -m screamsheet.db.nfl_teams_sync
+"""
+
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+import requests
+
+from ._nhl_db_shared import get_db_path
+from .team_lookup_db import init_db, upsert_teams
+
+logger = logging.getLogger(__name__)
+
+_ESPN_NFL_TEAMS_URL = (
+    "http://site.api.espn.com/apis/site/v2/sports/football/nfl/teams"
+)
+
+
+def fetch_teams() -> List[dict]:
+    """Fetch all NFL teams from the ESPN API.
+
+    Returns:
+        List of team dicts ready to pass to upsert_teams().
+
+    Raises:
+        requests.exceptions.HTTPError: on a non-2xx response.
+    """
+    response = requests.get(_ESPN_NFL_TEAMS_URL, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+
+    try:
+        teams_list = (
+            data.get("sports", [])[0]
+            .get("leagues", [])[0]
+            .get("teams", [])
+        )
+    except IndexError:
+        logger.warning("nfl fetch_teams: unexpected ESPN response structure")
+        return []
+
+    teams = []
+    for entry in teams_list:
+        team_info = entry.get("team", {})
+        try:
+            team_id = int(team_info.get("id", 0))
+        except (TypeError, ValueError):
+            continue
+        full_name = team_info.get("displayName", "")
+        abbrev = team_info.get("abbreviation", "")
+        if team_id and full_name:
+            teams.append({
+                "team_id":  team_id,
+                "full_name": full_name,
+                "abbrev":   abbrev,
+            })
+
+    return teams
+
+
+def full_sync(db_path: Optional[Path] = None) -> int:
+    """Fetch all NFL teams and upsert them into the local cache.
+
+    Args:
+        db_path: Path to the SQLite file.  Defaults to get_db_path().
+
+    Returns:
+        Number of rows upserted.
+    """
+    init_db("nfl", db_path)
+    teams = fetch_teams()
+    logger.info("nfl full_sync: fetched %d teams", len(teams))
+    count = upsert_teams("nfl", teams, db_path)
+    logger.info("nfl full_sync: complete — %d teams upserted", count)
+    return count
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    rows = full_sync()
+    print(f"NFL sync complete: {rows} teams upserted to {get_db_path()}")

--- a/src/screamsheet/db/nhl_teams_sync.py
+++ b/src/screamsheet/db/nhl_teams_sync.py
@@ -23,6 +23,10 @@ import requests
 
 from .nhl_teams_db import init_db, upsert_teams
 from ._nhl_db_shared import get_db_path
+from .team_lookup_db import (
+    init_db as _canonical_init_db,
+    upsert_teams as _canonical_upsert,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +85,35 @@ def full_sync_teams(db_path: Optional[Path] = None) -> int:
     logger.info("full_sync_teams: fetched %d teams", len(teams))
     count = upsert_teams(teams, db_path)
     logger.info("full_sync_teams: complete — %d teams upserted", count)
+    return count
+
+
+def full_sync_canonical_teams(db_path: Optional[Path] = None) -> int:
+    """Fetch all NHL teams and upsert them into the canonical nhl_teams table.
+
+    Uses the same standings data as full_sync_teams() but writes to the
+    nhl_teams table (id, team_id, full_name, abbrev, last_synced) instead
+    of the legacy teams table.
+
+    Args:
+        db_path: Path to the SQLite file.  Defaults to get_db_path().
+
+    Returns:
+        Number of rows upserted.
+    """
+    _canonical_init_db("nhl", db_path)
+    raw_teams = fetch_teams_from_standings()
+    canonical = [
+        {
+            "team_id":  t["team_id"],
+            "full_name": f"{t['city']} {t['team_full_name']}".strip(),
+            "abbrev":   t["team"],
+        }
+        for t in raw_teams
+    ]
+    logger.info("full_sync_canonical_teams: fetched %d teams", len(canonical))
+    count = _canonical_upsert("nhl", canonical, db_path)
+    logger.info("full_sync_canonical_teams: complete — %d teams upserted", count)
     return count
 
 

--- a/src/screamsheet/db/team_lookup_db.py
+++ b/src/screamsheet/db/team_lookup_db.py
@@ -1,0 +1,233 @@
+"""SQLite ORM models and lookup helpers for per-sport team tables.
+
+All four sports share an identical table schema:
+
+    <sport>_teams (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        team_id     INTEGER NOT NULL,
+        full_name   VARCHAR(150) NOT NULL,
+        abbrev      VARCHAR(10),
+        last_synced VARCHAR(25)
+    )
+
+Tables: nhl_teams, mlb_teams, nba_teams, nfl_teams
+
+Public API:
+    init_db(sport, db_path)                        Create table if missing → Engine
+    upsert_teams(sport, teams, db_path)            Bulk idempotent upsert → count
+    lookup_team_by_id(sport, team_id, db_path)     → dict | None
+    lookup_team_by_abbrev(sport, abbrev, db_path)  → dict | None
+    lookup_team_by_name(sport, fragment, db_path)  → list[dict]
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Literal, Optional
+
+from sqlalchemy import Column, Integer, String, create_engine, text
+from sqlalchemy.orm import Session
+
+from ._nhl_db_shared import _Base, get_db_path
+
+logger = logging.getLogger(__name__)
+
+Sport = Literal["nhl", "mlb", "nba", "nfl"]
+
+
+# ---------------------------------------------------------------------------
+# ORM models — one per sport, identical schema, different __tablename__
+# ---------------------------------------------------------------------------
+
+class _NHLTeam(_Base):
+    __tablename__ = "nhl_teams"
+    id          = Column(Integer, primary_key=True, autoincrement=True)
+    team_id     = Column(Integer, nullable=False, index=True)
+    full_name   = Column(String(150), nullable=False)
+    abbrev      = Column(String(10), index=True)
+    last_synced = Column(String(25))
+
+
+class _MLBTeam(_Base):
+    __tablename__ = "mlb_teams"
+    id          = Column(Integer, primary_key=True, autoincrement=True)
+    team_id     = Column(Integer, nullable=False, index=True)
+    full_name   = Column(String(150), nullable=False)
+    abbrev      = Column(String(10), index=True)
+    last_synced = Column(String(25))
+
+
+class _NBATeam(_Base):
+    __tablename__ = "nba_teams"
+    id          = Column(Integer, primary_key=True, autoincrement=True)
+    team_id     = Column(Integer, nullable=False, index=True)
+    full_name   = Column(String(150), nullable=False)
+    abbrev      = Column(String(10), index=True)
+    last_synced = Column(String(25))
+
+
+class _NFLTeam(_Base):
+    __tablename__ = "nfl_teams"
+    id          = Column(Integer, primary_key=True, autoincrement=True)
+    team_id     = Column(Integer, nullable=False, index=True)
+    full_name   = Column(String(150), nullable=False)
+    abbrev      = Column(String(10), index=True)
+    last_synced = Column(String(25))
+
+
+_MODELS: dict[str, type] = {
+    "nhl": _NHLTeam,
+    "mlb": _MLBTeam,
+    "nba": _NBATeam,
+    "nfl": _NFLTeam,
+}
+
+
+# ---------------------------------------------------------------------------
+# Engine / init
+# ---------------------------------------------------------------------------
+
+def _get_engine(db_path: Optional[Path] = None):
+    """Return a SQLAlchemy engine, creating all sport-team tables if needed."""
+    path = db_path or get_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    engine = create_engine(f"sqlite:///{path}", echo=False)
+    _Base.metadata.create_all(engine)
+    return engine
+
+
+def init_db(sport: Sport, db_path: Optional[Path] = None):
+    """Create the <sport>_teams table if it does not exist.
+
+    Args:
+        sport:   One of "nhl", "mlb", "nba", "nfl".
+        db_path: Path to the SQLite file.  Defaults to get_db_path().
+
+    Returns:
+        SQLAlchemy Engine bound to the database.
+    """
+    engine = _get_engine(db_path)
+    logger.debug("init_db: %s_teams ready at %s", sport, db_path or get_db_path())
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# Write
+# ---------------------------------------------------------------------------
+
+def upsert_teams(
+    sport: Sport,
+    teams: List[Dict],
+    db_path: Optional[Path] = None,
+) -> int:
+    """Idempotent bulk upsert of team dicts into the <sport>_teams table.
+
+    Each dict must contain ``team_id`` and ``full_name``.
+    Optional: ``abbrev``.  ``last_synced`` is always set to the current UTC
+    timestamp.
+
+    Args:
+        sport:   Target sport table.
+        teams:   List of team dicts.
+        db_path: Path to the SQLite file.  Defaults to get_db_path().
+
+    Returns:
+        Number of rows successfully upserted.
+    """
+    model_cls = _MODELS[sport]
+    table = model_cls.__tablename__
+    engine = _get_engine(db_path)
+    now = datetime.now(timezone.utc).isoformat()
+    count = 0
+    with Session(engine) as session:
+        for t in teams:
+            tid = t.get("team_id")
+            if tid is None:
+                logger.warning(
+                    "upsert_teams(%s): skipping entry without team_id: %s", sport, t
+                )
+                continue
+            session.execute(
+                text(f"DELETE FROM {table} WHERE team_id = :tid"), {"tid": tid}
+            )
+            session.add(model_cls(
+                team_id     = tid,
+                full_name   = (t.get("full_name") or "")[:150],
+                abbrev      = (t.get("abbrev") or "")[:10],
+                last_synced = now,
+            ))
+            count += 1
+        session.commit()
+    logger.debug("upsert_teams(%s): upserted %d rows", sport, count)
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Read
+# ---------------------------------------------------------------------------
+
+def _row_to_dict(row) -> Dict:
+    return {
+        "id":          row.id,
+        "team_id":     row.team_id,
+        "full_name":   row.full_name,
+        "abbrev":      row.abbrev,
+        "last_synced": row.last_synced,
+    }
+
+
+def lookup_team_by_id(
+    sport: Sport,
+    team_id: int,
+    db_path: Optional[Path] = None,
+) -> Optional[Dict]:
+    """Look up a team by its numeric team_id.
+
+    Returns:
+        Dict of team fields, or None if not in cache.
+    """
+    model_cls = _MODELS[sport]
+    engine = _get_engine(db_path)
+    with Session(engine) as session:
+        row = session.query(model_cls).filter(model_cls.team_id == team_id).first()
+        return _row_to_dict(row) if row else None
+
+
+def lookup_team_by_abbrev(
+    sport: Sport,
+    abbrev: str,
+    db_path: Optional[Path] = None,
+) -> Optional[Dict]:
+    """Look up a team by abbreviation (case-insensitive).
+
+    Returns:
+        Dict of team fields, or None if not in cache.
+    """
+    model_cls = _MODELS[sport]
+    engine = _get_engine(db_path)
+    with Session(engine) as session:
+        row = session.query(model_cls).filter(
+            model_cls.abbrev.ilike(abbrev)
+        ).first()
+        return _row_to_dict(row) if row else None
+
+
+def lookup_team_by_name(
+    sport: Sport,
+    name_fragment: str,
+    db_path: Optional[Path] = None,
+) -> List[Dict]:
+    """Case-insensitive partial match on full_name.
+
+    Returns:
+        List of matching team dicts (may be empty).
+    """
+    model_cls = _MODELS[sport]
+    engine = _get_engine(db_path)
+    with Session(engine) as session:
+        rows = session.query(model_cls).filter(
+            model_cls.full_name.ilike(f"%{name_fragment}%")
+        ).all()
+        return [_row_to_dict(r) for r in rows]

--- a/tests/test_nhl_players_db.py
+++ b/tests/test_nhl_players_db.py
@@ -83,7 +83,7 @@ class TestInitDb:
     def test_get_db_path_returns_path(self):
         result = get_db_path()
         assert isinstance(result, Path)
-        assert result.name == "nhl.db"
+        assert result.name == "screamsheet.db"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sport_teams_db.py
+++ b/tests/test_sport_teams_db.py
@@ -1,0 +1,166 @@
+"""Unit tests for the multi-sport team lookup DB (team_lookup_db).
+
+Each test verifies exactly one behaviour (SRP).
+All tests run against a tmp_path SQLite file — no network, no real DB.
+"""
+
+import pytest
+
+from screamsheet.db.team_lookup_db import (
+    init_db,
+    lookup_team_by_abbrev,
+    lookup_team_by_id,
+    lookup_team_by_name,
+    upsert_teams,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(params=["nhl", "mlb", "nba", "nfl"])
+def sport(request):
+    return request.param
+
+
+@pytest.fixture
+def db(tmp_path, sport):
+    path = tmp_path / "test.db"
+    init_db(sport, path)
+    return path
+
+
+@pytest.fixture
+def phillies():
+    return {"team_id": 143, "full_name": "Philadelphia Phillies", "abbrev": "PHI"}
+
+
+@pytest.fixture
+def padres():
+    return {"team_id": 135, "full_name": "San Diego Padres", "abbrev": "SD"}
+
+
+# ---------------------------------------------------------------------------
+# init_db
+# ---------------------------------------------------------------------------
+
+class TestInitDb:
+    def test_creates_db_file(self, tmp_path, sport):
+        path = tmp_path / "teams.db"
+        init_db(sport, path)
+        assert path.exists()
+
+    def test_creates_sport_table(self, tmp_path, sport):
+        import sqlalchemy as sa
+        path = tmp_path / "teams.db"
+        engine = init_db(sport, path)
+        assert f"{sport}_teams" in sa.inspect(engine).get_table_names()
+
+
+# ---------------------------------------------------------------------------
+# upsert_teams
+# ---------------------------------------------------------------------------
+
+class TestUpsertTeams:
+    def test_inserts_row(self, db, sport, phillies):
+        count = upsert_teams(sport, [phillies], db)
+        assert count == 1
+
+    def test_returns_count_for_multiple_teams(self, db, sport, phillies, padres):
+        count = upsert_teams(sport, [phillies, padres], db)
+        assert count == 2
+
+    def test_is_idempotent(self, db, sport, phillies):
+        upsert_teams(sport, [phillies], db)
+        upsert_teams(sport, [phillies], db)
+        # Still only one row — no duplicates
+        results = lookup_team_by_name(sport, "Philadelphia Phillies", db)
+        assert len(results) == 1
+
+    def test_updates_existing_row(self, db, sport, phillies):
+        upsert_teams(sport, [phillies], db)
+        updated = {**phillies, "full_name": "Updated Phillies"}
+        upsert_teams(sport, [updated], db)
+        result = lookup_team_by_id(sport, phillies["team_id"], db)
+        assert result["full_name"] == "Updated Phillies"
+
+    def test_skips_entry_without_team_id(self, db, sport):
+        count = upsert_teams(sport, [{"full_name": "No ID Team", "abbrev": "NON"}], db)
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# lookup_team_by_id
+# ---------------------------------------------------------------------------
+
+class TestLookupTeamById:
+    def test_returns_dict_for_known_id(self, db, sport, phillies):
+        upsert_teams(sport, [phillies], db)
+        result = lookup_team_by_id(sport, 143, db)
+        assert result is not None
+        assert result["full_name"] == "Philadelphia Phillies"
+
+    def test_returns_none_for_unknown_id(self, db, sport):
+        result = lookup_team_by_id(sport, 9999, db)
+        assert result is None
+
+    def test_result_contains_required_fields(self, db, sport, phillies):
+        upsert_teams(sport, [phillies], db)
+        result = lookup_team_by_id(sport, 143, db)
+        for field in ("team_id", "full_name", "abbrev", "last_synced"):
+            assert field in result
+
+
+# ---------------------------------------------------------------------------
+# lookup_team_by_abbrev
+# ---------------------------------------------------------------------------
+
+class TestLookupTeamByAbbrev:
+    def test_returns_dict_for_known_abbrev(self, db, sport, phillies):
+        upsert_teams(sport, [phillies], db)
+        result = lookup_team_by_abbrev(sport, "PHI", db)
+        assert result is not None
+        assert result["team_id"] == 143
+
+    def test_is_case_insensitive_lower(self, db, sport, phillies):
+        upsert_teams(sport, [phillies], db)
+        assert lookup_team_by_abbrev(sport, "phi", db) is not None
+
+    def test_is_case_insensitive_mixed(self, db, sport, phillies):
+        upsert_teams(sport, [phillies], db)
+        assert lookup_team_by_abbrev(sport, "Phi", db) is not None
+
+    def test_returns_none_for_unknown_abbrev(self, db, sport):
+        result = lookup_team_by_abbrev(sport, "XYZ", db)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# lookup_team_by_name
+# ---------------------------------------------------------------------------
+
+class TestLookupTeamByName:
+    def test_returns_matching_team(self, db, sport, phillies, padres):
+        upsert_teams(sport, [phillies, padres], db)
+        results = lookup_team_by_name(sport, "Philadelphia", db)
+        assert len(results) == 1
+        assert results[0]["abbrev"] == "PHI"
+
+    def test_partial_match(self, db, sport, phillies, padres):
+        upsert_teams(sport, [phillies, padres], db)
+        results = lookup_team_by_name(sport, "San", db)
+        assert len(results) == 1
+        assert results[0]["abbrev"] == "SD"
+
+    def test_returns_empty_list_for_no_match(self, db, sport, phillies):
+        upsert_teams(sport, [phillies], db)
+        results = lookup_team_by_name(sport, "Toronto", db)
+        assert results == []
+
+    def test_returns_all_matching_teams(self, db, sport, phillies):
+        angels  = {"team_id": 108, "full_name": "Los Angeles Angels",  "abbrev": "LAA"}
+        dodgers = {"team_id": 119, "full_name": "Los Angeles Dodgers", "abbrev": "LAD"}
+        upsert_teams(sport, [phillies, angels, dodgers], db)
+        results = lookup_team_by_name(sport, "Los Angeles", db)
+        assert len(results) == 2

--- a/update_db.sh
+++ b/update_db.sh
@@ -24,9 +24,8 @@ cd "$SCRIPT_DIR"
 
 # Directories and dated log file
 mkdir -p ./logfiles
-DB_DIR="${SCRIPT_DIR}/src/screamsheet/db"
-mkdir -p "$DB_DIR"
-DB_PATH="${DB_DIR}/nhl.db"
+DB_PATH="${HOME}/database/screamsheet.db"
+mkdir -p "$(dirname "$DB_PATH")"
 DATE=$(date +%Y%m%d)
 LOG_FILE="./logfiles/update_db_log_${DATE}.txt"
 


### PR DESCRIPTION
… path

- Add team_lookup_db.py: ORM models and helpers for nhl_teams, mlb_teams, nba_teams, nfl_teams tables (team_id, full_name, abbrev, last_synced)
- Add mlb_teams_sync.py (statsapi.mlb.com), nba_teams_sync.py (nba_api static), nfl_teams_sync.py (ESPN API)
- Add full_sync_canonical_teams() to nhl_teams_sync.py for new nhl_teams table
- Rewrite db_update.py to sync all four sports + legacy NHL players/teams
- Migrate default DB filename from nhl.db → screamsheet.db
- Add SCREAMSHEET_DB env var support to get_db_path()
- Add DbConfig and database.path to config.py and config.yaml.example
- Thread DB path from config through __main__.py via env var
- Fix update_db.sh DB_PATH to ~/database/screamsheet.db
- Add __DB_PATH__ placeholder to config.yaml.example; wire DB_PATH GitHub variable into deploy.yaml sed substitution (same pattern as PRINT_DIR)
- Update db/__init__.py to export multi-sport helpers alongside legacy NHL API
- Add tests/test_sport_teams_db.py (TDD, all four sports parameterized)
- Fix test_get_db_path_returns_path to expect screamsheet.db

Closes #84