### PR TITLE
ci: remove config.yaml generation and execution from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,34 +38,15 @@ jobs:
           # We use $GITHUB_WORKSPACE which is where actions/checkout put the code
           rsync -a --exclude='env' --exclude='.venv' --exclude='__pycache__' --exclude='.git' "$GITHUB_WORKSPACE/" "$RELEASE_DIR/"
 
-          # 3. Generate config.yaml from the example, substituting the PRINT_DIR variable.
-          #    This overwrites the developer's local config.yaml that rsync copied above.
-          sed \
-            -e 's|__PRINT_DIR__|${{ vars.PRINT_DIR }}|g' \
-            -e 's|__DB_PATH__|${{ vars.DB_PATH }}|g' \
-            -e 's|__PERSON1_NAME__|${{ vars.PERSON1_NAME }}|g' \
-            -e 's|__PERSON1_SUN_SIGN__|${{ vars.PERSON1_SUN_SIGN }}|g' \
-            -e 's|__PERSON1_MOON_SIGN__|${{ vars.PERSON1_MOON_SIGN }}|g' \
-            -e 's|__PERSON1_ASCENDANT__|${{ vars.PERSON1_ASCENDANT }}|g' \
-            -e 's|__PERSON2_NAME__|${{ vars.PERSON2_NAME }}|g' \
-            -e 's|__PERSON2_SUN_SIGN__|${{ vars.PERSON2_SUN_SIGN }}|g' \
-            -e 's|__PERSON2_MOON_SIGN__|${{ vars.PERSON2_MOON_SIGN }}|g' \
-            -e 's|__PERSON2_ASCENDANT__|${{ vars.PERSON2_ASCENDANT }}|g' \
-            "$RELEASE_DIR/config.yaml.example" > "$RELEASE_DIR/config.yaml"
-
-          # 4. UV Sync
+          # 3. UV Sync
           cd "$RELEASE_DIR"
           uv sync --frozen
 
-          # 5. Set Permissions
+          # 4. Set Permissions
           chmod +x "$RELEASE_DIR/screamsheet.sh"
 
-          # 6. Atomic Switch
+          # 5. Atomic Switch
           ln -snf "$RELEASE_DIR" "$LIVE_PATH"
-
-          # 7. Final Execution
-          echo "Executing screamsheet.sh via uv run with email output override..."
-          uv run ./screamsheet.sh --output-dir /home/peter/EMAIL/
 
       - name: Cleanup Old Releases
         run: |

--- a/README.md
+++ b/README.md
@@ -213,30 +213,12 @@ The `--output-dir` flag takes precedence over `config.yaml`. If `output.director
 
 #### CI / deploy setup
 
-`config.yaml.example` contains placeholders that the deploy workflow substitutes using **GitHub repository variables** (Settings → Secrets and variables → Actions → **Variables** tab):
+Deployments sync code to the deployment server and update dependencies via `uv sync`. Note that `config.yaml` is not recreated during deployment as all runs of `screamsheet` are handled via the `screamsheet-subscriber` repository.
 
-| Variable | Description | Example |
-|---|---|---|
-| `PRINT_DIR` | Output directory on the server for generated PDFs | `/home/peter/Print` |
-| `PERSON1_NAME` | Display name for person 1's horoscope column | `Peter` |
-| `PERSON1_SUN_SIGN` | Sun sign for person 1 | `Gemini` |
-| `PERSON1_MOON_SIGN` | Moon sign for person 1 | `Scorpio` |
-| `PERSON1_ASCENDANT` | Ascendant (rising) sign for person 1 | `Sagittarius` |
-| `PERSON2_NAME` | Display name for person 2's horoscope column | `Jane` |
-| `PERSON2_SUN_SIGN` | Sun sign for person 2 | `Pisces` |
-| `PERSON2_MOON_SIGN` | Moon sign for person 2 | `Taurus` |
-| `PERSON2_ASCENDANT` | Ascendant (rising) sign for person 2 | `Cancer` |
-
-Valid zodiac sign values are: `Aries`, `Taurus`, `Gemini`, `Cancer`, `Leo`, `Virgo`, `Libra`, `Scorpio`, `Sagittarius`, `Capricorn`, `Aquarius`, `Pisces`.
-
-Use **Variables**, not **Secrets**, for these values. These sign/name values are not sensitive, and Variables are easier to view and manage.
-
-After setting/updating variables, trigger deploy from the Actions tab:
+To trigger deploy from the Actions tab:
 
 1. Open **Deploy Scream Sheet**
 2. Click **Run workflow**
-
-No path is hardcoded in the workflow YAML.
 
 ### DB cache — NHL teams & players (refresh weekly)
 

--- a/src/screamsheet/__main__.py
+++ b/src/screamsheet/__main__.py
@@ -10,6 +10,7 @@ Usage:
 import argparse
 import logging
 import shutil
+import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 from .config import load_config
@@ -360,31 +361,36 @@ def main():
     except FileNotFoundError:
         pass  # config.yaml missing — env var / platform default will be used
 
-    if args.single:
-        sheets, output_dir = _build_sheets(today_str)
-        if args.output_dir:
-            output_dir = args.output_dir
-        if isinstance(args.single, str):
-            query = args.single.lower().replace("-", "_").replace(" ", "_")
-            chosen = None
-            for label, factory_fn in sheets:
-                label_norm = label.lower().replace("-", "_").replace(" ", "_")
-                if query in label_norm or (query == "mlb_allstar" and "all_star" in label_norm):
-                    chosen = (label, factory_fn)
-                    break
-            if chosen:
-                print(f"\nRunning selected screamsheet: {chosen[0]}\n")
-                _run_sheet(chosen[0], chosen[1], output_dir)
+    try:
+        if args.single:
+            sheets, output_dir = _build_sheets(today_str)
+            if args.output_dir:
+                output_dir = args.output_dir
+            if isinstance(args.single, str):
+                query = args.single.lower().replace("-", "_").replace(" ", "_")
+                chosen = None
+                for label, factory_fn in sheets:
+                    label_norm = label.lower().replace("-", "_").replace(" ", "_")
+                    if query in label_norm or (query == "mlb_allstar" and "all_star" in label_norm):
+                        chosen = (label, factory_fn)
+                        break
+                if chosen:
+                    print(f"\nRunning selected screamsheet: {chosen[0]}\n")
+                    _run_sheet(chosen[0], chosen[1], output_dir)
+                else:
+                    print(f"\nNo screamsheet matched '{args.single}'. Opening interactive selection...")
+                    _pick_and_run(sheets, output_dir)
             else:
-                print(f"\nNo screamsheet matched '{args.single}'. Opening interactive selection...")
                 _pick_and_run(sheets, output_dir)
         else:
-            _pick_and_run(sheets, output_dir)
-    else:
-        order = _build_order_from_config(today)
-        if args.output_dir:
-            order.output = OutputOrderOptions(directory=args.output_dir)
-        run_order(order, today=today)
+            order = _build_order_from_config(today)
+            if args.output_dir:
+                order.output = OutputOrderOptions(directory=args.output_dir)
+            run_order(order, today=today)
+    except FileNotFoundError as err:
+        logging.getLogger(__name__).info("config.yaml not found: %s", err)
+        print(f"[info] config.yaml not found ({err}). Exiting gracefully.")
+        sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/src/screamsheet/runner.py
+++ b/src/screamsheet/runner.py
@@ -280,6 +280,9 @@ def run_order(
 
     result = ScreamsheetResult(subscriber_name=subscriber_name)
 
+    if subscriber_name:
+        logger.info("\nGenerating screamsheets for subscriber %s", subscriber_name)
+
     for f in dataclasses.fields(order):
         if f.name in _SKIP_FIELDS:
             continue

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -94,6 +94,12 @@ class TestRunSheet:
 
 
 class TestBuildOrderFromConfig:
+    @pytest.fixture(autouse=True)
+    def mock_config(self, monkeypatch):
+        from screamsheet.config import load_config
+        example_path = Path(__file__).parents[1] / "config.yaml.example"
+        monkeypatch.setattr("screamsheet.__main__.load_config", lambda: load_config(example_path))
+
     def test_worldcup_not_in_batch_order(self):
         from datetime import datetime
         from screamsheet.__main__ import _build_order_from_config

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -115,3 +115,16 @@ class TestBuildOrderFromConfig:
         assert order.french_mlb_news is not None
         assert isinstance(order.french_mlb_news.news_names, list)
 
+
+class TestMainMissingConfig:
+    def test_main_exits_gracefully_when_config_missing(self, monkeypatch, capsys):
+        from screamsheet.__main__ import main
+        monkeypatch.setattr("screamsheet.__main__.load_config", MagicMock(side_effect=FileNotFoundError("Config file not found")))
+        monkeypatch.setattr("sys.argv", ["screamsheet"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "config.yaml" in captured.out or "config.yaml" in captured.err
+

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -139,6 +139,15 @@ class TestRunOrder:
         result = run_order(order, today=_TODAY, subscriber_name="Peter Martinson")
         assert result.subscriber_name == "Peter Martinson"
 
+    def test_subscriber_name_is_logged(self, caplog) -> None:
+        import logging
+
+        order = ScreamsheetOrder()
+        with caplog.at_level(logging.INFO, logger="screamsheet.runner"):
+            run_order(order, today=_TODAY, subscriber_name="Asher Martinson")
+
+        assert any("Generating screamsheets for subscriber Asher Martinson" in r.message for r in caplog.records)
+
 
 class TestPersonOptions:
     def test_birth_fields_default_to_empty_strings(self) -> None:


### PR DESCRIPTION
Branch: subscriber-only. All runs of screamsheet are now handled externally via the screamsheet-subscriber repository.